### PR TITLE
add native oci, c9 and dfp liquidity

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -21,6 +21,9 @@
     "enabled": true,
     "rules": {
       "recommended": true,
+      "style": {
+        "noNonNullAssertion": "off"
+      },
       "correctness": {
         "useYield": "off"
       }

--- a/packages/api/src/common/address-validation/addressValidation.ts
+++ b/packages/api/src/common/address-validation/addressValidation.ts
@@ -11,6 +11,7 @@ import { SurgeConstants } from "../dapps/surge/constants";
 import { Assets } from "../assets/constants";
 import {
   flatTokenNameMap,
+  nativeAssets,
   xrdDerivatives,
   type TokenInfo,
 } from "./tokenNameMap";
@@ -80,7 +81,7 @@ export class AddressValidationService extends Context.Tag(
     getTokenName: (
       resourceAddress: string
     ) => Effect.Effect<string, UnknownTokenError>;
-    getTokenNameAndXrdStatus: (
+    getTokenNameAndNativeAssetStatus: (
       resourceAddress: string
     ) => Effect.Effect<TokenInfo, UnknownTokenError>;
   }
@@ -595,7 +596,7 @@ export const AddressValidationServiceLive = Layer.succeed(
       return Effect.fail(new UnknownTokenError(resourceAddress));
     },
 
-    getTokenNameAndXrdStatus: (
+    getTokenNameAndNativeAssetStatus: (
       resourceAddress: string
     ): Effect.Effect<TokenInfo, UnknownTokenError> => {
       const tokenName =
@@ -604,7 +605,7 @@ export const AddressValidationServiceLive = Layer.succeed(
       if (tokenName) {
         return Effect.succeed({
           name: tokenName,
-          isXrdDerivative: xrdDerivatives.has(resourceAddress),
+          isNativeAsset: nativeAssets.has(resourceAddress),
         });
       }
 

--- a/packages/api/src/common/address-validation/tokenNameMap.ts
+++ b/packages/api/src/common/address-validation/tokenNameMap.ts
@@ -1,12 +1,36 @@
 import { Assets } from "../assets/constants";
 import { CaviarNineConstants } from "../dapps/caviarnine/constants";
 
-// Centralized token name mapping (consolidated from TokenNameService)
+// Centralized token mapping with XRD derivative classification
 export const tokenNameMap = {
-  [Assets.Fungible.XRD]: "xrd",
-  [Assets.Fungible.xUSDC]: "xusdc",
-  [Assets.Fungible.xUSDT]: "xusdt",
-  [Assets.Fungible.wxBTC]: "xwbtc",
-  [Assets.Fungible.xETH]: "xeth",
-  [CaviarNineConstants.LSULP.resourceAddress]: "lsulp",
+  // XRD derivatives
+  xrdDerivatives: {
+    [Assets.Fungible.XRD]: "xrd",
+    [CaviarNineConstants.LSULP.resourceAddress]: "lsulp",
+    [Assets.Fungible.OCI]: "oci",
+    [Assets.Fungible.EARLY]: "early",
+    [Assets.Fungible.ILIS]: "ilis",
+    [Assets.Fungible.DFP2]: "dfp2",
+    [Assets.Fungible.ASTRL]: "astrl",
+  },
+  // Non-XRD derivatives
+  nonXrdDerivatives: {
+    [Assets.Fungible.xUSDC]: "xusdc",
+    [Assets.Fungible.xUSDT]: "xusdt",
+    [Assets.Fungible.wxBTC]: "xwbtc",
+    [Assets.Fungible.xETH]: "xeth",
+  },
 } as const;
+
+export const flatTokenNameMap = {
+  ...tokenNameMap.xrdDerivatives,
+  ...tokenNameMap.nonXrdDerivatives,
+} as const;
+
+// A set of XRD derivatives for quick lookup
+export const xrdDerivatives = new Set(Object.keys(tokenNameMap.xrdDerivatives));
+
+export type TokenInfo = {
+  name: string;
+  isXrdDerivative: boolean;
+};

--- a/packages/api/src/common/address-validation/tokenNameMap.ts
+++ b/packages/api/src/common/address-validation/tokenNameMap.ts
@@ -1,10 +1,10 @@
 import { Assets } from "../assets/constants";
 import { CaviarNineConstants } from "../dapps/caviarnine/constants";
 
-// Centralized token mapping with XRD derivative classification
+// Centralized token mapping with native and wrapped asset classification
 export const tokenNameMap = {
-  // XRD derivatives
-  xrdDerivatives: {
+  // Native Radix assets
+  nativeAssets: {
     [Assets.Fungible.XRD]: "xrd",
     [CaviarNineConstants.LSULP.resourceAddress]: "lsulp",
     [Assets.Fungible.OCI]: "oci",
@@ -15,8 +15,8 @@ export const tokenNameMap = {
     [Assets.Fungible.FLOOP]: "floop",
     [Assets.Fungible.REDDICKS]: "reddicks",
   },
-  // Non-XRD derivatives
-  nonXrdDerivatives: {
+  // Wrapped/bridged assets
+  wrappedAssets: {
     [Assets.Fungible.xUSDC]: "xusdc",
     [Assets.Fungible.xUSDT]: "xusdt",
     [Assets.Fungible.wxBTC]: "xwbtc",
@@ -25,14 +25,21 @@ export const tokenNameMap = {
 } as const;
 
 export const flatTokenNameMap = {
-  ...tokenNameMap.xrdDerivatives,
-  ...tokenNameMap.nonXrdDerivatives,
+  ...tokenNameMap.nativeAssets,
+  ...tokenNameMap.wrappedAssets,
 } as const;
 
-// A set of XRD derivatives for quick lookup
-export const xrdDerivatives = new Set(Object.keys(tokenNameMap.xrdDerivatives));
+// A set of native assets for quick lookup
+export const nativeAssets = new Set(Object.keys(tokenNameMap.nativeAssets));
+
+// A set of XRD derivatives for quick lookup (subset of native assets, used in aggregateXrdBalances.ts)
+export const xrdDerivatives = new Set([
+  Assets.Fungible.XRD,
+  CaviarNineConstants.LSULP.resourceAddress,
+  // LSUs and unstaking receipts would be added here when needed
+]);
 
 export type TokenInfo = {
   name: string;
-  isXrdDerivative: boolean;
+  isNativeAsset: boolean;
 };

--- a/packages/api/src/common/address-validation/tokenNameMap.ts
+++ b/packages/api/src/common/address-validation/tokenNameMap.ts
@@ -12,6 +12,8 @@ export const tokenNameMap = {
     [Assets.Fungible.ILIS]: "ilis",
     [Assets.Fungible.DFP2]: "dfp2",
     [Assets.Fungible.ASTRL]: "astrl",
+    [Assets.Fungible.FLOOP]: "floop",
+    [Assets.Fungible.REDDICKS]: "reddicks",
   },
   // Non-XRD derivatives
   nonXrdDerivatives: {

--- a/packages/api/src/common/assets/constants.ts
+++ b/packages/api/src/common/assets/constants.ts
@@ -1,6 +1,8 @@
 export const Assets = {
   Fungible: {
     XRD: "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+
+    //wrapped instabridge
     wxBTC:
       "resource_rdx1t580qxc7upat7lww4l2c4jckacafjeudxj5wpjrrct0p3e82sq4y75",
     xUSDC:
@@ -8,5 +10,14 @@ export const Assets = {
     xETH: "resource_rdx1th88qcj5syl9ghka2g9l7tw497vy5x6zaatyvgfkwcfe8n9jt2npww",
     xUSDT:
       "resource_rdx1thrvr3xfs2tarm2dl9emvs26vjqxu6mqvfgvqjne940jv0lnrrg7rw",
+
+    //ecosystem
+    OCI: "resource_rdx1t52pvtk5wfhltchwh3rkzls2x0r98fw9cjhpyrf3vsykhkuwrf7jg8",
+    EARLY:
+      "resource_rdx1t5xv44c0u99z096q00mv74emwmxwjw26m98lwlzq6ddlpe9f5cuc7s",
+    ILIS: "resource_rdx1t4r86qqjtzl8620ahvsxuxaf366s6rf6cpy24psdkmrlkdqvzn47c2",
+    DFP2: "resource_rdx1t5ywq4c6nd2lxkemkv4uzt8v7x7smjcguzq5sgafwtasa6luq7fclq",
+    ASTRL:
+      "resource_rdx1t4tjx4g3qzd98nayqxm7qdpj0a0u8ns6a0jrchq49dyfevgh6u0gj3",
   },
 } as const;

--- a/packages/api/src/common/assets/constants.ts
+++ b/packages/api/src/common/assets/constants.ts
@@ -19,5 +19,9 @@ export const Assets = {
     DFP2: "resource_rdx1t5ywq4c6nd2lxkemkv4uzt8v7x7smjcguzq5sgafwtasa6luq7fclq",
     ASTRL:
       "resource_rdx1t4tjx4g3qzd98nayqxm7qdpj0a0u8ns6a0jrchq49dyfevgh6u0gj3",
+    FLOOP:
+      "resource_rdx1t5pyvlaas0ljxy0wytm5gvyamyv896m69njqdmm2stukr3xexc2up9",
+    REDDICKS:
+      "resource_rdx1t42hpqvsk4t42l6aw09hwphd2axvetp6gvas9ztue0p30f4hzdwxrp",
   },
 } as const;

--- a/packages/api/src/common/dapps/caviarnine/constants.ts
+++ b/packages/api/src/common/dapps/caviarnine/constants.ts
@@ -3,6 +3,9 @@ import { Assets } from "../../assets/constants";
 export type ShapeLiquidityPool =
   (typeof CaviarNineConstants.shapeLiquidityPools)[keyof typeof CaviarNineConstants.shapeLiquidityPools];
 
+export type SimplePool =
+  (typeof CaviarNineConstants.simplePools)[keyof typeof CaviarNineConstants.simplePools];
+
 export const CaviarNineConstants = {
   LSULP: {
     component:
@@ -68,6 +71,28 @@ export const CaviarNineConstants = {
       liquidity_receipt:
         "resource_rdx1nft63kjp38agw0z8nnwkyjhcgpzwjer84945h5z8yr663fgukjyp3l",
     },
+    FLOOP_XRD: {
+      name: "FLOOP/XRD",
+      componentAddress:
+        "component_rdx1czgaazn4wqf40kav57t8tu6kwv2a5sfmnlzlar9ee6kdqk0ll2chsz",
+      token_x: Assets.Fungible.FLOOP,
+      token_y: Assets.Fungible.XRD,
+      liquidity_receipt:
+        "resource_rdx1ntpkcfe5ny37wk487ruuxj8wrgk6qg8rjq80m08un4yg98dmyj6msq",
+    },
+  },
+  simplePools: {
+    REDDICKS_LSULP: {
+      name: "REDDICKS/LSULP",
+      componentAddress:
+        "component_rdx1cz7s2xn8ddpmgm3uw0ma4jhaxhxdwce253v9j5agvffhftny6rgh8n",
+      poolAddress: "pool_rdx1chmx480a0crrnaqyg2e6tr7wtqwk5239grzs6ecckcmhqjm3gdmm73",
+      lpResourceAddress:
+        "resource_rdx1tkjspzkzmhyzxwcrjha3y2aapmg5690vayjehqtfa729jnr88hcaue",
+      token_x: Assets.Fungible.REDDICKS,
+      token_y:
+        "resource_rdx1thksg5ng70g9mmy9ne7wz0sc7auzrrwy7fmgcxzel2gvp8pj0xxfmf",
+    },
   },
 } as const;
 
@@ -80,6 +105,13 @@ export const shapeLiquidityReceiptSet = new Map<string, ShapeLiquidityPool>(
 
 export const shapeLiquidityComponentSet = new Map<string, ShapeLiquidityPool>(
   Object.values(CaviarNineConstants.shapeLiquidityPools).map((pool) => [
+    pool.componentAddress,
+    pool,
+  ])
+);
+
+export const simplePoolComponentSet = new Map<string, SimplePool>(
+  Object.values(CaviarNineConstants.simplePools).map((pool) => [
     pool.componentAddress,
     pool,
   ])

--- a/packages/api/src/common/dapps/caviarnine/constants.ts
+++ b/packages/api/src/common/dapps/caviarnine/constants.ts
@@ -86,12 +86,24 @@ export const CaviarNineConstants = {
       name: "REDDICKS/LSULP",
       componentAddress:
         "component_rdx1cz7s2xn8ddpmgm3uw0ma4jhaxhxdwce253v9j5agvffhftny6rgh8n",
-      poolAddress: "pool_rdx1chmx480a0crrnaqyg2e6tr7wtqwk5239grzs6ecckcmhqjm3gdmm73",
+      poolAddress:
+        "pool_rdx1chmx480a0crrnaqyg2e6tr7wtqwk5239grzs6ecckcmhqjm3gdmm73",
       lpResourceAddress:
         "resource_rdx1tkjspzkzmhyzxwcrjha3y2aapmg5690vayjehqtfa729jnr88hcaue",
       token_x: Assets.Fungible.REDDICKS,
       token_y:
         "resource_rdx1thksg5ng70g9mmy9ne7wz0sc7auzrrwy7fmgcxzel2gvp8pj0xxfmf",
+    },
+    FLOOP_XRD: {
+      name: "FLOOP/XRD",
+      componentAddress:
+        "component_rdx1cpc6hjytxcvddl3e38u9amkn52ly3vzw6r0pxu54ge43l4ttw9ym7c",
+      poolAddress:
+        "pool_rdx1ch3vyhagpzqll4cu6quafdpkf7lvyuz7ke4z66tuqpxhvtxzd9lvmu",
+      lpResourceAddress:
+        "resource_rdx1th2pnc0lzgp20wwv2r22knjn32ntvecapws6v7z644c0d3rzz0fvng",
+      token_x: Assets.Fungible.FLOOP,
+      token_y: Assets.Fungible.XRD,
     },
   },
 } as const;

--- a/packages/api/src/common/dapps/caviarnine/getCaviarnineResourcePoolPositions.test.ts
+++ b/packages/api/src/common/dapps/caviarnine/getCaviarnineResourcePoolPositions.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from "vitest";
+import { Effect, Layer } from "effect";
+import {
+  GetCaviarnineResourcePoolPositionsLive,
+  GetCaviarnineResourcePoolPositionsService,
+} from "./getCaviarnineResourcePoolPositions";
+import { GatewayApiClientLive } from "../../gateway/gatewayApiClient";
+import { GetEntityDetailsServiceLive } from "../../gateway/getEntityDetails";
+import { GetFungibleBalanceLive } from "../../gateway/getFungibleBalance";
+import {
+  GetResourcePoolUnitsLive,
+  GetResourcePoolUnitsService,
+} from "../../resource-pool/getResourcePoolUnits";
+import { EntityFungiblesPageLive } from "../../gateway/entityFungiblesPage";
+
+const TEST_ACCOUNT =
+  "account_rdx12xl2meqtelz47mwp3nzd72jkwyallg5yxr9hkc75ac4qztsxulfpew";
+
+const gatewayApiClientLive = GatewayApiClientLive;
+
+const getEntityDetailsServiceLive = GetEntityDetailsServiceLive.pipe(
+  Layer.provide(gatewayApiClientLive)
+);
+
+const entityFungiblesPageServiceLive = EntityFungiblesPageLive.pipe(
+  Layer.provide(gatewayApiClientLive)
+);
+
+const getFungibleBalanceLive = GetFungibleBalanceLive.pipe(
+  Layer.provide(gatewayApiClientLive),
+  Layer.provide(entityFungiblesPageServiceLive)
+);
+
+const getResourcePoolUnitsLive = GetResourcePoolUnitsLive.pipe(
+  Layer.provide(getFungibleBalanceLive),
+  Layer.provide(getEntityDetailsServiceLive)
+);
+
+const getCaviarnineResourcePoolPositionsLive =
+  GetCaviarnineResourcePoolPositionsLive.pipe(
+    Layer.provide(getFungibleBalanceLive),
+    Layer.provide(getResourcePoolUnitsLive)
+  );
+
+describe("getCaviarnineResourcePoolPositions", () => {
+  it("should fetch SimplePool positions without errors", async () => {
+    const program = Effect.gen(function* () {
+      const service = yield* GetCaviarnineResourcePoolPositionsService;
+
+      const result = yield* service.getCaviarnineResourcePoolPositions({
+        addresses: [TEST_ACCOUNT],
+        at_ledger_state: { state_version: 329748623 },
+      });
+
+      console.log(
+        "Caviarnine SimplePool positions result:",
+        JSON.stringify(result, null, 2)
+      );
+      return result;
+    });
+
+    await Effect.runPromise(
+      Effect.provide(program, getCaviarnineResourcePoolPositionsLive)
+    );
+  });
+
+  it("should handle empty results gracefully", async () => {
+    const program = Effect.gen(function* () {
+      const service = yield* GetCaviarnineResourcePoolPositionsService;
+
+      const result = yield* service.getCaviarnineResourcePoolPositions({
+        addresses: ["account_rdx1000000000000000000000000000000000000000000000000000000"],
+        at_ledger_state: { state_version: 329748623 },
+      });
+
+      console.log("Empty result:", JSON.stringify(result, null, 2));
+      return result;
+    });
+
+    await Effect.runPromise(
+      Effect.provide(program, getCaviarnineResourcePoolPositionsLive)
+    );
+  });
+});

--- a/packages/api/src/common/dapps/caviarnine/getCaviarnineResourcePoolPositions.test.ts
+++ b/packages/api/src/common/dapps/caviarnine/getCaviarnineResourcePoolPositions.test.ts
@@ -47,7 +47,7 @@ describe("getCaviarnineResourcePoolPositions", () => {
     const program = Effect.gen(function* () {
       const service = yield* GetCaviarnineResourcePoolPositionsService;
 
-      const result = yield* service.getCaviarnineResourcePoolPositions({
+      const result = yield* service.run({
         addresses: [TEST_ACCOUNT],
         at_ledger_state: { state_version: 329748623 },
       });
@@ -68,8 +68,10 @@ describe("getCaviarnineResourcePoolPositions", () => {
     const program = Effect.gen(function* () {
       const service = yield* GetCaviarnineResourcePoolPositionsService;
 
-      const result = yield* service.getCaviarnineResourcePoolPositions({
-        addresses: ["account_rdx1000000000000000000000000000000000000000000000000000000"],
+      const result = yield* service.run({
+        addresses: [
+          "account_rdx1000000000000000000000000000000000000000000000000000000",
+        ],
         at_ledger_state: { state_version: 329748623 },
       });
 

--- a/packages/api/src/common/dapps/caviarnine/getCaviarnineResourcePoolPositions.ts
+++ b/packages/api/src/common/dapps/caviarnine/getCaviarnineResourcePoolPositions.ts
@@ -1,0 +1,159 @@
+import { Effect } from "effect";
+import BigNumber from "bignumber.js";
+
+import { GetFungibleBalanceService } from "../../gateway/getFungibleBalance";
+
+import { CaviarNineConstants } from "./constants";
+import type { AtLedgerState } from "../../gateway/schemas";
+
+import { GetResourcePoolUnitsService } from "../../resource-pool/getResourcePoolUnits";
+
+export class InvalidResourcePoolError extends Error {
+  readonly _tag = "InvalidResourcePoolError";
+  constructor(error: unknown) {
+    super(
+      `Invalid resource pool error: ${error instanceof Error ? error.message : error}`
+    );
+  }
+}
+
+import type { ShapeLiquidityAsset } from "./getShapeLiquidityAssets";
+
+export type GetCaviarnineResourcePoolPositionsOutput = {
+  pool: (typeof CaviarNineConstants.simplePools)[keyof typeof CaviarNineConstants.simplePools];
+  result: {
+    address: string;
+    items: ShapeLiquidityAsset[];
+  }[];
+}[];
+
+type AccountAddress = string;
+
+export class GetCaviarnineResourcePoolPositionsService extends Effect.Service<GetCaviarnineResourcePoolPositionsService>()(
+  "GetCaviarnineResourcePoolPositionsService",
+  {
+    effect: Effect.gen(function* () {
+      const getFungibleBalanceService = yield* GetFungibleBalanceService;
+      const getResourcePoolUnitsService = yield* GetResourcePoolUnitsService;
+
+      return {
+        getCaviarnineResourcePoolPositions: Effect.fn(
+          (input: {
+            addresses: AccountAddress[];
+            at_ledger_state: AtLedgerState;
+          }) =>
+            Effect.gen(function* () {
+              const allPoolAddresses = Object.values(
+                CaviarNineConstants.simplePools
+              ).map((pool) => pool.poolAddress);
+
+              // Get pool units for all simple pools
+              const poolUnitsResults = yield* getResourcePoolUnitsService({
+                addresses: allPoolAddresses,
+                at_ledger_state: input.at_ledger_state,
+              });
+
+              // Create a map of pool address to pool configuration
+              const poolConfigMap = new Map();
+              for (const [key, pool] of Object.entries(
+                CaviarNineConstants.simplePools
+              )) {
+                poolConfigMap.set(pool.poolAddress, { key, ...pool });
+              }
+
+              // Get fungible balances for user addresses
+              const fungibleBalance = yield* getFungibleBalanceService({
+                addresses: input.addresses,
+                at_ledger_state: input.at_ledger_state,
+              });
+
+              const poolResults: GetCaviarnineResourcePoolPositionsOutput = [];
+
+              for (const poolUnit of poolUnitsResults) {
+                const poolConfig = poolConfigMap.get(
+                  poolUnit.address
+                );
+                if (!poolConfig) continue;
+
+                const addressResults: {
+                  address: string;
+                  items: ShapeLiquidityAsset[];
+                }[] = [];
+
+                for (const address of input.addresses) {
+                  const addressBalance = fungibleBalance.find(
+                    (item) => item.address === address
+                  );
+
+                  const lpBalance = addressBalance?.fungibleResources.find(
+                    (resource) =>
+                      resource.resourceAddress === poolUnit.lpResourceAddress
+                  );
+
+                  if (!lpBalance || new BigNumber(lpBalance.amount).eq(0)) {
+                    addressResults.push({
+                      address,
+                      items: [],
+                    });
+                    continue;
+                  }
+
+                  // Calculate token amounts based on LP token amount and pool unit values
+                  const lpAmount = new BigNumber(lpBalance.amount);
+
+                  const xTokenPool = poolUnit.poolResources.find(
+                    (resource) =>
+                      resource.resourceAddress === poolConfig.token_x
+                  );
+                  const yTokenPool = poolUnit.poolResources.find(
+                    (resource) =>
+                      resource.resourceAddress === poolConfig.token_y
+                  );
+
+                  // poolUnitValue already represents the value per LP token, so just multiply by LP balance
+                  const xTokenAmount = xTokenPool
+                    ? xTokenPool.poolUnitValue.multipliedBy(lpAmount).toString()
+                    : "0";
+                  const yTokenAmount = yTokenPool
+                    ? yTokenPool.poolUnitValue.multipliedBy(lpAmount).toString()
+                    : "0";
+
+                  const liquidityAsset: ShapeLiquidityAsset = {
+                    xToken: {
+                      withinPriceBounds: xTokenAmount, // For simple pools, all liquidity is "within bounds"
+                      outsidePriceBounds: "0", // Simple pools don't have concentrated liquidity
+                      resourceAddress: poolConfig.token_x,
+                    },
+                    yToken: {
+                      withinPriceBounds: yTokenAmount, // For simple pools, all liquidity is "within bounds"
+                      outsidePriceBounds: "0", // Simple pools don't have concentrated liquidity
+                      resourceAddress: poolConfig.token_y,
+                    },
+                    currentPrice: "1", // Simple pools don't track exact price
+                    nonFungibleId: "", // Simple pools use fungible LP tokens
+                    resourceAddress: poolConfig.lpResourceAddress,
+                    isActive: true, // Simple pools are always active
+                  };
+
+                  addressResults.push({
+                    address,
+                    items: [liquidityAsset],
+                  });
+                }
+
+                poolResults.push({
+                  pool: poolConfig,
+                  result: addressResults,
+                });
+              }
+
+              return poolResults;
+            })
+        ),
+      };
+    }),
+  }
+) {}
+
+export const GetCaviarnineResourcePoolPositionsLive =
+  GetCaviarnineResourcePoolPositionsService.Default;

--- a/packages/api/src/common/dapps/caviarnine/getCaviarnineResourcePoolPositions.ts
+++ b/packages/api/src/common/dapps/caviarnine/getCaviarnineResourcePoolPositions.ts
@@ -20,8 +20,6 @@ export class InvalidResourcePoolError extends Error {
   }
 }
 
-import type { ShapeLiquidityAsset } from "./getShapeLiquidityAssets";
-
 export type CaviarnineSimplePoolLiquidityAsset = {
   xToken: {
     withinPriceBounds: string;
@@ -58,111 +56,107 @@ export class GetCaviarnineResourcePoolPositionsService extends Effect.Service<Ge
           at_ledger_state: AtLedgerState;
           fungibleBalance?: GetFungibleBalanceOutput;
         }) =>
-            Effect.gen(function* () {
-              const allPoolAddresses = Object.values(
-                CaviarNineConstants.simplePools
-              ).map((pool) => pool.poolAddress);
+          Effect.gen(function* () {
+            const allPoolAddresses = Object.values(
+              CaviarNineConstants.simplePools
+            ).map((pool) => pool.poolAddress);
 
-              // Get pool units for all simple pools
-              const poolUnitsResults = yield* getResourcePoolUnitsService({
-                addresses: allPoolAddresses,
+            // Get pool units for all simple pools
+            const poolUnitsResults = yield* getResourcePoolUnitsService({
+              addresses: allPoolAddresses,
+              at_ledger_state: input.at_ledger_state,
+            });
+
+            // Create a map of pool address to pool configuration
+            const poolConfigMap = new Map();
+            for (const [key, pool] of Object.entries(
+              CaviarNineConstants.simplePools
+            )) {
+              poolConfigMap.set(pool.poolAddress, { key, ...pool });
+            }
+
+            // Get fungible balances for user addresses (if not provided)
+            const fungibleBalance =
+              input.fungibleBalance ??
+              (yield* getFungibleBalanceService({
+                addresses: input.addresses,
                 at_ledger_state: input.at_ledger_state,
-              });
+              }));
 
-              // Create a map of pool address to pool configuration
-              const poolConfigMap = new Map();
-              for (const [key, pool] of Object.entries(
-                CaviarNineConstants.simplePools
-              )) {
-                poolConfigMap.set(pool.poolAddress, { key, ...pool });
-              }
+            const poolResults: GetCaviarnineResourcePoolPositionsOutput = [];
 
-              // Get fungible balances for user addresses (if not provided)
-              const fungibleBalance =
-                input.fungibleBalance ??
-                (yield* getFungibleBalanceService({
-                  addresses: input.addresses,
-                  at_ledger_state: input.at_ledger_state,
-                }));
+            for (const poolUnit of poolUnitsResults) {
+              const poolConfig = poolConfigMap.get(poolUnit.address);
+              if (!poolConfig) continue;
 
-              const poolResults: GetCaviarnineResourcePoolPositionsOutput = [];
+              const addressResults: {
+                address: string;
+                items: CaviarnineSimplePoolLiquidityAsset[];
+              }[] = [];
 
-              for (const poolUnit of poolUnitsResults) {
-                const poolConfig = poolConfigMap.get(
-                  poolUnit.address
+              for (const address of input.addresses) {
+                const addressBalance = fungibleBalance.find(
+                  (item) => item.address === address
                 );
-                if (!poolConfig) continue;
 
-                const addressResults: {
-                  address: string;
-                  items: CaviarnineSimplePoolLiquidityAsset[];
-                }[] = [];
+                const lpBalance = addressBalance?.fungibleResources.find(
+                  (resource) =>
+                    resource.resourceAddress === poolUnit.lpResourceAddress
+                );
 
-                for (const address of input.addresses) {
-                  const addressBalance = fungibleBalance.find(
-                    (item) => item.address === address
-                  );
-
-                  const lpBalance = addressBalance?.fungibleResources.find(
-                    (resource) =>
-                      resource.resourceAddress === poolUnit.lpResourceAddress
-                  );
-
-                  if (!lpBalance || new BigNumber(lpBalance.amount).eq(0)) {
-                    addressResults.push({
-                      address,
-                      items: [],
-                    });
-                    continue;
-                  }
-
-                  // Calculate token amounts based on LP token amount and pool unit values
-                  const lpAmount = new BigNumber(lpBalance.amount);
-
-                  const xTokenPool = poolUnit.poolResources.find(
-                    (resource) =>
-                      resource.resourceAddress === poolConfig.token_x
-                  );
-                  const yTokenPool = poolUnit.poolResources.find(
-                    (resource) =>
-                      resource.resourceAddress === poolConfig.token_y
-                  );
-
-                  // poolUnitValue already represents the value per LP token, so just multiply by LP balance
-                  const xTokenAmount = xTokenPool
-                    ? xTokenPool.poolUnitValue.multipliedBy(lpAmount).toString()
-                    : "0";
-                  const yTokenAmount = yTokenPool
-                    ? yTokenPool.poolUnitValue.multipliedBy(lpAmount).toString()
-                    : "0";
-
-                  const liquidityAsset: CaviarnineSimplePoolLiquidityAsset = {
-                    xToken: {
-                      withinPriceBounds: xTokenAmount, // For simple pools, all liquidity is "within bounds"
-                      outsidePriceBounds: "0", // Simple pools don't have concentrated liquidity
-                      resourceAddress: poolConfig.token_x,
-                    },
-                    yToken: {
-                      withinPriceBounds: yTokenAmount, // For simple pools, all liquidity is "within bounds"
-                      outsidePriceBounds: "0", // Simple pools don't have concentrated liquidity
-                      resourceAddress: poolConfig.token_y,
-                    },
-                  };
-
+                if (!lpBalance || new BigNumber(lpBalance.amount).eq(0)) {
                   addressResults.push({
                     address,
-                    items: [liquidityAsset],
+                    items: [],
                   });
+                  continue;
                 }
 
-                poolResults.push({
-                  pool: poolConfig,
-                  result: addressResults,
+                // Calculate token amounts based on LP token amount and pool unit values
+                const lpAmount = new BigNumber(lpBalance.amount);
+
+                const xTokenPool = poolUnit.poolResources.find(
+                  (resource) => resource.resourceAddress === poolConfig.token_x
+                );
+                const yTokenPool = poolUnit.poolResources.find(
+                  (resource) => resource.resourceAddress === poolConfig.token_y
+                );
+
+                // poolUnitValue already represents the value per LP token, so just multiply by LP balance
+                const xTokenAmount = xTokenPool
+                  ? xTokenPool.poolUnitValue.multipliedBy(lpAmount).toString()
+                  : "0";
+                const yTokenAmount = yTokenPool
+                  ? yTokenPool.poolUnitValue.multipliedBy(lpAmount).toString()
+                  : "0";
+
+                const liquidityAsset: CaviarnineSimplePoolLiquidityAsset = {
+                  xToken: {
+                    withinPriceBounds: xTokenAmount, // For simple pools, all liquidity is "within bounds"
+                    outsidePriceBounds: "0", // Simple pools don't have concentrated liquidity
+                    resourceAddress: poolConfig.token_x,
+                  },
+                  yToken: {
+                    withinPriceBounds: yTokenAmount, // For simple pools, all liquidity is "within bounds"
+                    outsidePriceBounds: "0", // Simple pools don't have concentrated liquidity
+                    resourceAddress: poolConfig.token_y,
+                  },
+                };
+
+                addressResults.push({
+                  address,
+                  items: [liquidityAsset],
                 });
               }
 
-              return poolResults;
-            }),
+              poolResults.push({
+                pool: poolConfig,
+                result: addressResults,
+              });
+            }
+
+            return poolResults;
+          }),
       };
     }),
   }

--- a/packages/api/src/common/dapps/caviarnine/getShapeLiquidityAssets.ts
+++ b/packages/api/src/common/dapps/caviarnine/getShapeLiquidityAssets.ts
@@ -198,7 +198,6 @@ export const GetShapeLiquidityAssetsLive = Layer.effect(
           Effect.map((items) =>
             items.map((nft) => ({
               ...nft,
-              // biome-ignore lint/style/noNonNullAssertion: <explanation>
               address: nftOwnerMap.get(nft.nonFungibleId)!,
             }))
           )

--- a/packages/api/src/common/dapps/caviarnine/getShapeLiquidityAssets.ts
+++ b/packages/api/src/common/dapps/caviarnine/getShapeLiquidityAssets.ts
@@ -1,16 +1,9 @@
 import { Context, Effect, Layer } from "effect";
 
 import type { AtLedgerState } from "../../gateway/schemas";
-import type {
-  GetEntityDetailsError,
-  GetEntityDetailsService,
-} from "../../gateway/getEntityDetails";
-import type { EntityNonFungibleDataService } from "../../gateway/entityNonFungiblesData";
-import type { GatewayApiClientService } from "../../gateway/gatewayApiClient";
+import type { GetEntityDetailsError } from "../../gateway/getEntityDetails";
 import { QuantaSwap } from "./schemas";
 import type { EntityNotFoundError, GatewayError } from "../../gateway/errors";
-import type { KeyValueStoreDataService } from "../../gateway/keyValueStoreData";
-import type { KeyValueStoreKeysService } from "../../gateway/keyValueStoreKeys";
 
 import {
   GetComponentStateService,
@@ -21,14 +14,12 @@ import {
   GetNonFungibleBalanceService,
   type InvalidInputError,
 } from "../../gateway/getNonFungibleBalance";
-import type { GetLedgerStateService } from "../../gateway/getLedgerState";
 import { GetQuantaSwapBinMapService } from "./getQuantaSwapBinMap";
 import {
   type FailedToParseLiquidityClaimsError,
   GetShapeLiquidityClaimsService,
 } from "./getShapeLiquidityClaims";
 import { I192 } from "../../helpers/i192";
-import type { EntityNonFungiblesPageService } from "../../gateway/entityNonFungiblesPage";
 import { calculatePrice, calculateTick } from "./tickCalculator";
 
 export class FailedToParseComponentStateError {

--- a/packages/api/src/common/dapps/caviarnine/schemas.ts
+++ b/packages/api/src/common/dapps/caviarnine/schemas.ts
@@ -67,6 +67,19 @@ export const HLPSwapEvent = s.struct({
   treasury_fee: s.decimal(),
 });
 
+// SimplePool has the same SwapEvent structure as HLP but without oracle_price
+export const SimplePoolSwapEvent = s.struct({
+  input_resource: s.address(),
+  output_resource: s.address(),
+  input_amount: s.decimal(),
+  output_amount: s.decimal(),
+  input_reserve: s.decimal(),
+  output_reserve: s.decimal(),
+  liquidity_fee: s.decimal(),
+  protocol_fee: s.decimal(),
+  treasury_fee: s.decimal(),
+});
+
 export const RemoveLiquidityEvent = s.struct({
   liquidity_receipt_id: s.nonFungibleLocalId(),
   amount_change_x: s.decimal(),
@@ -95,3 +108,4 @@ export type AddLiquidityEvent = s.infer<typeof AddLiquidityEvent>;
 export type RemoveLiquidityEvent = s.infer<typeof RemoveLiquidityEvent>;
 export type SwapEvent = s.infer<typeof SwapEvent>;
 export type HLPSwapEvent = s.infer<typeof HLPSwapEvent>;
+export type SimplePoolSwapEvent = s.infer<typeof SimplePoolSwapEvent>;

--- a/packages/api/src/common/dapps/defiplaza/constants.ts
+++ b/packages/api/src/common/dapps/defiplaza/constants.ts
@@ -60,6 +60,36 @@ export const DefiPlaza = {
     componentAddress:
       "component_rdx1czzqr5m40x3sklwntcmx8uw3ld5nj7marq66nm6erp3prw7rv8zu29",
   },
+  ASTRLPool: {
+    type: "component",
+    basePoolAddress:
+      "pool_rdx1c47jlmd9stptfy2a7e39wnjfechu72q9ggus29x0mqf98m8xt70rx2",
+    baseLpResourceAddress:
+      "resource_rdx1t5q26nr5t02pzf40tp9z999ex7d84szldnpqg8e459jyvztrxhqqls",
+    quotePoolAddress:
+      "pool_rdx1c4xm5wfm92vh39dzszzv3huvdmvz73juhkw8vls0z4fg2vfr0wkv93",
+    quoteLpResourceAddress:
+      "resource_rdx1tkuuhphx2rtdytucgt0ucnd4k8zymxdeta4xa2req93yuaup3s244u",
+    baseResourceAddress: Assets.Fungible.ASTRL,
+    quoteResourceAddress: Assets.Fungible.DFP2,
+    componentAddress:
+      "component_rdx1cqvxkaazmpnvg3f9ufc5n2msv6x7ztjdusdm06lhtf5n7wr8guggg5", //make sure this is PlazaPair component, not Dex
+  },
+  XRDPool: {
+    type: "component",
+    basePoolAddress:
+      "pool_rdx1chxn0nqj840r78t2ah5agchq4ue9p65q23nc9ckqfe0mmjstq8fyg0",
+    baseLpResourceAddress:
+      "resource_rdx1tknxlx2sy23qkg6twvnu3kqcd5l4daacq0n6mdam54upqgx50f4ju8",
+    quotePoolAddress:
+      "pool_rdx1c4547fnprjhlp2m27aycmf8rzrkrfzcck58jt2706r85gpcaeapz7k",
+    quoteLpResourceAddress:
+      "resource_rdx1t4a5clnxmnctmezaty08cuugfzmj2lezqcjk2szezrfdfl4w4ederu",
+    baseResourceAddress: Assets.Fungible.XRD,
+    quoteResourceAddress: Assets.Fungible.DFP2,
+    componentAddress:
+      "component_rdx1cppd8rq7gfwad75z56mz9tldqmw4aps48hqnx2stf4eeew8v6tyd72",
+  },
 } as const;
 
 export const defiPlazaComponentSet = new Map<

--- a/packages/api/src/common/dapps/ociswap/constants.ts
+++ b/packages/api/src/common/dapps/ociswap/constants.ts
@@ -47,13 +47,64 @@ export const OciswapConstants = {
       divisibility_y: 6,
     },
   },
+  poolsV2: {
+    OCI_XRD: {
+      name: "OCI/XRD",
+      componentAddress:
+        "component_rdx1crm530ath85gcwm4gvwq8m70ay07df085kmupp6gte3ew94vg5pdcp",
+      lpResourceAddress:
+        "resource_rdx1n2qukjm07d26matv7cyc5ev2f942uy44zn9h3x7p8hnm9dah5flht4",
+      token_x: Assets.Fungible.OCI,
+      token_y: Assets.Fungible.XRD,
+      divisibility_x: 18,
+      divisibility_y: 18,
+    },
+  },
+  basicPools: {
+    EARLY_XRD: {
+      name: "EARLY/XRD",
+      componentAddress:
+        "component_rdx1cz8p5lc8vmj96hdguy02hkfq4z5xyxf9k759dj8ym8exj8x8zgmw9p",
+      poolAddress:
+        "pool_rdx1c5hm2rt67scp22pq6tpkfg6cd22g0wwz88065wsy9gdfnd86sv3t4t",
+      lpResourceAddress:
+        "resource_rdx1t5362v5zqsfkfe38uyl368edpsdm23u5g69qt55jn0ye8nf6umnnv9",
+      token_x: Assets.Fungible.EARLY,
+      token_y: Assets.Fungible.XRD,
+    },
+  },
+  flexPools: {
+    ILIS_XRD: {
+      name: "ILIS/XRD",
+      componentAddress:
+        "component_rdx1cr9tj8xd5cjs9mzkqdnamrzq0xgy4eylk75vhqqzka5uxsxatv4wxd",
+      poolAddress:
+        "pool_rdx1c5cyh7lhxly2mxzsmrs4c99vhxt9jzap3gaf7s8h0h68fqlpfht0un",
+      lpResourceAddress:
+        "resource_rdx1t4qxj7nnm0sra6f6j9jq73erd489hdad6jp92hggtfwgwy9p2mgn76",
+      token_x: Assets.Fungible.ILIS,
+      token_y: Assets.Fungible.XRD,
+    },
+  },
 } as const;
 
 export type OciswapPool =
   (typeof OciswapConstants.pools)[keyof typeof OciswapConstants.pools];
 
+export type OciswapPoolV2 =
+  (typeof OciswapConstants.poolsV2)[keyof typeof OciswapConstants.poolsV2];
+
+export type AllOciswapPools = OciswapPool | OciswapPoolV2;
+
 export const ociswapComponentSet = new Map<string, OciswapPool>(
   Object.values(OciswapConstants.pools).map((pool) => [
+    pool.componentAddress,
+    pool,
+  ])
+);
+
+export const ociswapV2ComponentSet = new Map<string, OciswapPoolV2>(
+  Object.values(OciswapConstants.poolsV2).map((pool) => [
     pool.componentAddress,
     pool,
   ])

--- a/packages/api/src/common/dapps/ociswap/constants.ts
+++ b/packages/api/src/common/dapps/ociswap/constants.ts
@@ -72,6 +72,17 @@ export const OciswapConstants = {
       token_x: Assets.Fungible.EARLY,
       token_y: Assets.Fungible.XRD,
     },
+    OCI_XRD: {
+      name: "OCI/XRD",
+      componentAddress:
+        "component_rdx1cz89w3ecvh9jvdd892vycs44rr042lteg75zgdydq9csn5d87snvdw",
+      poolAddress:
+        "pool_rdx1ckyg8aujf09uh8qlz6asst75g5w6pl6vu8nl6qrhskawcndyk6585y",
+      lpResourceAddress:
+        "resource_rdx1th7ew2u9c9t00xhk34efm9uj8zxnme48h4ypuerv5uu4ftz8j82gdm",
+      token_x: Assets.Fungible.OCI,
+      token_y: Assets.Fungible.XRD,
+    },
   },
   flexPools: {
     ILIS_XRD: {

--- a/packages/api/src/common/dapps/ociswap/getOciswapLiquidityAssets.test.ts
+++ b/packages/api/src/common/dapps/ociswap/getOciswapLiquidityAssets.test.ts
@@ -21,30 +21,39 @@ import { EntityNonFungiblesPageLive } from "../../gateway/entityNonFungiblesPage
 import { GetNonFungibleIdsLive } from "../../gateway/getNonFungibleIds";
 
 const TEST_CONFIG = {
-  // Pool component address
-  componentAddress:
-    "component_rdx1cz8daq5nwmtdju4hj5rxud0ta26wf90sdk5r4nj9fqjcde5eht8p0f",
+  // V1 Pool (xUSDC/XRD)
+  v1: {
+    componentAddress:
+      "component_rdx1cz8daq5nwmtdju4hj5rxud0ta26wf90sdk5r4nj9fqjcde5eht8p0f",
+    lpResourceAddress:
+      "resource_rdx1nflrqd24a8xqelasygwlt6dhrgtu3akky695kk6j3cy4wu0wfn2ef8",
+    tokenXAddress:
+      "resource_rdx1t4upr78guuapv5ept7d7ptekk9mqhy605zgms33mcszen8l9fac8vf",
+    tokenYAddress:
+      "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+    tokenXDivisibility: 6,
+    tokenYDivisibility: 18,
+    nftId: "#435#",
+  },
 
-  // LP NFT resource address for this pool
-  lpResourceAddress:
-    "resource_rdx1nflrqd24a8xqelasygwlt6dhrgtu3akky695kk6j3cy4wu0wfn2ef8",
-
-  // Token addresses
-  tokenXAddress:
-    "resource_rdx1t4upr78guuapv5ept7d7ptekk9mqhy605zgms33mcszen8l9fac8vf",
-  tokenYAddress:
-    "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
-
-  // Token divisibilities
-  tokenXDivisibility: 18,
-  tokenYDivisibility: 18,
+  // V2 Pool (OCI/XRD)
+  v2: {
+    componentAddress:
+      "component_rdx1crm530ath85gcwm4gvwq8m70ay07df085kmupp6gte3ew94vg5pdcp",
+    lpResourceAddress:
+      "resource_rdx1n2qukjm07d26matv7cyc5ev2f942uy44zn9h3x7p8hnm9dah5flht4",
+    tokenXAddress:
+      "resource_rdx1t52pvtk5wfhltchwh3rkzls2x0r98fw9cjhpyrf3vsykhkuwrf7jg8", // Correct OCI address
+    tokenYAddress:
+      "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+    tokenXDivisibility: 18,
+    tokenYDivisibility: 18,
+    nftId: "#1#",
+  },
 
   // Test user address that holds LP NFTs
   userAddress:
     "account_rdx12xl2meqtelz47mwp3nzd72jkwyallg5yxr9hkc75ac4qztsxulfpew",
-
-  // Specific NFT ID to test
-  nftId: "#435#",
 
   // Price bounds for testing
   priceBounds: {
@@ -128,25 +137,26 @@ const TestLive = Layer.mergeAll(
 );
 
 describe("OciSwap Liquidity Assets Test", () => {
-  it("should calculate liquidity assets with normal price bounds", async () => {
+  it.skip("should calculate liquidity assets with v1 schema", async () => {
     const program = Effect.provide(
       Effect.gen(function* () {
         const getOciswapLiquidityAssetsService =
           yield* GetOciswapLiquidityAssetsService;
 
         const result = yield* getOciswapLiquidityAssetsService({
-          componentAddress: TEST_CONFIG.componentAddress,
+          componentAddress: TEST_CONFIG.v1.componentAddress,
           addresses: [TEST_CONFIG.userAddress],
-          at_ledger_state: { state_version: 321803265 },
-          lpResourceAddress: TEST_CONFIG.lpResourceAddress,
-          tokenXAddress: TEST_CONFIG.tokenXAddress,
-          tokenYAddress: TEST_CONFIG.tokenYAddress,
-          tokenXDivisibility: TEST_CONFIG.tokenXDivisibility,
-          tokenYDivisibility: TEST_CONFIG.tokenYDivisibility,
+          at_ledger_state: { state_version: 328823647 },
+          lpResourceAddress: TEST_CONFIG.v1.lpResourceAddress,
+          tokenXAddress: TEST_CONFIG.v1.tokenXAddress,
+          tokenYAddress: TEST_CONFIG.v1.tokenYAddress,
+          tokenXDivisibility: TEST_CONFIG.v1.tokenXDivisibility,
+          tokenYDivisibility: TEST_CONFIG.v1.tokenYDivisibility,
+          schemaVersion: "v1",
           priceBounds: TEST_CONFIG.priceBounds,
         });
 
-        console.log("=== NORMAL PRICE BOUNDS TEST ===");
+        console.log("=== V1 SCHEMA TEST (xUSDC/XRD) ===");
         console.log("Price bounds:", TEST_CONFIG.priceBounds);
         console.log("Result:", JSON.stringify(result, null, 2));
 
@@ -170,24 +180,163 @@ describe("OciSwap Liquidity Assets Test", () => {
 
     // @ts-ignore - Ignoring type errors to test functionality
     const result = await Effect.runPromise(program);
-    console.log("Normal bounds result:", result);
+    console.log("V1 schema result:", result);
   });
 
-  it("should calculate liquidity assets with tight price bounds", async () => {
+  it.skip("should calculate liquidity assets with v2 schema", async () => {
     const program = Effect.provide(
       Effect.gen(function* () {
         const getOciswapLiquidityAssetsService =
           yield* GetOciswapLiquidityAssetsService;
 
         const result = yield* getOciswapLiquidityAssetsService({
-          componentAddress: TEST_CONFIG.componentAddress,
+          componentAddress: TEST_CONFIG.v2.componentAddress,
           addresses: [TEST_CONFIG.userAddress],
-          at_ledger_state: { state_version: 321803265 },
-          lpResourceAddress: TEST_CONFIG.lpResourceAddress,
-          tokenXAddress: TEST_CONFIG.tokenXAddress,
-          tokenYAddress: TEST_CONFIG.tokenYAddress,
-          tokenXDivisibility: TEST_CONFIG.tokenXDivisibility,
-          tokenYDivisibility: TEST_CONFIG.tokenYDivisibility,
+          at_ledger_state: { state_version: 328823647 },
+          lpResourceAddress: TEST_CONFIG.v2.lpResourceAddress,
+          tokenXAddress: TEST_CONFIG.v2.tokenXAddress,
+          tokenYAddress: TEST_CONFIG.v2.tokenYAddress,
+          tokenXDivisibility: TEST_CONFIG.v2.tokenXDivisibility,
+          tokenYDivisibility: TEST_CONFIG.v2.tokenYDivisibility,
+          schemaVersion: "v2",
+          priceBounds: TEST_CONFIG.priceBounds,
+        });
+
+        console.log("=== V2 SCHEMA TEST (OCI/XRD) ===");
+        console.log("Price bounds:", TEST_CONFIG.priceBounds);
+        console.log("Result:", JSON.stringify(result, null, 2));
+
+        // Show comparison clearly
+        if (result.length > 0 && result[0].items.length > 0) {
+          const item = result[0].items[0];
+          console.log("\n--- COMPARISON ---");
+          console.log(`X Token (${item.xToken.resourceAddress}):`);
+          console.log(`  Total: ${item.xToken.totalAmount}`);
+          console.log(`  In bounds: ${item.xToken.amountInBounds}`);
+          console.log(`Y Token (${item.yToken.resourceAddress}):`);
+          console.log(`  Total: ${item.yToken.totalAmount}`);
+          console.log(`  In bounds: ${item.yToken.amountInBounds}`);
+          console.log(`Active: ${item.isActive}`);
+        }
+
+        return result;
+      }),
+      TestLive
+    );
+
+    // @ts-ignore - Ignoring type errors to test functionality
+    const result = await Effect.runPromise(program);
+    console.log("V2 schema result:", result);
+  });
+
+  it("should debug V2 schema NFT detection step by step", async () => {
+    const program = Effect.provide(
+      Effect.gen(function* () {
+        const getNonFungibleBalanceService =
+          yield* GetNonFungibleBalanceService;
+        const getOciswapLiquidityAssetsService =
+          yield* GetOciswapLiquidityAssetsService;
+        const getOciswapLiquidityClaimsService =
+          yield* GetOciswapLiquidityClaimsService;
+
+        console.log("=== V2 DEBUG TEST ===");
+        console.log("Testing V2 pool:", TEST_CONFIG.v2.componentAddress);
+        console.log("LP Resource Address:", TEST_CONFIG.v2.lpResourceAddress);
+        console.log("Account:", TEST_CONFIG.userAddress);
+
+        // Step 1: Check NFT balance with NO resource filter (all NFTs)
+        console.log("\n🔍 Step 1: Checking ALL NFTs for account...");
+        const allNftBalance = yield* getNonFungibleBalanceService({
+          addresses: [TEST_CONFIG.userAddress],
+          at_ledger_state: { state_version: 328823647 },
+        });
+
+        console.log("All NFT Resources found:");
+        for (const item of allNftBalance.items) {
+          console.log(`Account: ${item.address}`);
+          for (const nftResource of item.nonFungibleResources) {
+            console.log(
+              `  - Resource: ${nftResource.resourceAddress} (${nftResource.items.length} NFTs)`
+            );
+            if (
+              nftResource.resourceAddress === TEST_CONFIG.v2.lpResourceAddress
+            ) {
+              console.log(
+                `    ⭐ FOUND V2 POOL NFTs! IDs: ${nftResource.items.map((i) => i.id).join(", ")}`
+              );
+            }
+          }
+        }
+
+        // Step 2: Check NFT balance with specific V2 resource filter
+        console.log("\n🔍 Step 2: Checking V2 pool NFTs specifically...");
+        const v2NftBalance = yield* getNonFungibleBalanceService({
+          addresses: [TEST_CONFIG.userAddress],
+          at_ledger_state: { state_version: 328823647 },
+          resourceAddresses: [TEST_CONFIG.v2.lpResourceAddress],
+        });
+
+        console.log(
+          "V2 NFT Balance result:",
+          JSON.stringify(v2NftBalance, null, 2)
+        );
+
+        // Step 3: Test V2 liquidity claims service first
+        console.log("\n🔍 Step 3a: Testing V2 liquidity claims service...");
+
+        try {
+          const v2Claims = yield* getOciswapLiquidityClaimsService({
+            lpResourceAddress: TEST_CONFIG.v2.lpResourceAddress,
+            nonFungibleLocalIds: ["#1005#"],
+            at_ledger_state: { state_version: 328823647 },
+          });
+          console.log("V2 Claims result:", JSON.stringify(v2Claims, null, 2));
+        } catch (error) {
+          console.log("V2 Claims failed:", error);
+        }
+
+        // Step 3b: Try the full service
+        console.log("\n🔍 Step 3b: Testing V2 liquidity assets service...");
+        const result = yield* getOciswapLiquidityAssetsService({
+          componentAddress: TEST_CONFIG.v2.componentAddress,
+          addresses: [TEST_CONFIG.userAddress],
+          at_ledger_state: { state_version: 328823647 },
+          lpResourceAddress: TEST_CONFIG.v2.lpResourceAddress,
+          tokenXAddress: TEST_CONFIG.v2.tokenXAddress,
+          tokenYAddress: TEST_CONFIG.v2.tokenYAddress,
+          tokenXDivisibility: TEST_CONFIG.v2.tokenXDivisibility,
+          tokenYDivisibility: TEST_CONFIG.v2.tokenYDivisibility,
+          schemaVersion: "v2",
+          priceBounds: TEST_CONFIG.priceBounds,
+        });
+
+        console.log("Final V2 result:", JSON.stringify(result, null, 2));
+
+        return result;
+      }),
+      TestLive
+    );
+
+    await Effect.runPromise(program);
+    console.log("V2 debug test completed");
+  }, 30000); // 30 second timeout
+
+  it.skip("should calculate liquidity assets with tight price bounds", async () => {
+    const program = Effect.provide(
+      Effect.gen(function* () {
+        const getOciswapLiquidityAssetsService =
+          yield* GetOciswapLiquidityAssetsService;
+
+        const result = yield* getOciswapLiquidityAssetsService({
+          componentAddress: TEST_CONFIG.v1.componentAddress,
+          addresses: [TEST_CONFIG.userAddress],
+          at_ledger_state: { state_version: 328823647 },
+          lpResourceAddress: TEST_CONFIG.v1.lpResourceAddress,
+          tokenXAddress: TEST_CONFIG.v1.tokenXAddress,
+          tokenYAddress: TEST_CONFIG.v1.tokenYAddress,
+          tokenXDivisibility: TEST_CONFIG.v1.tokenXDivisibility,
+          tokenYDivisibility: TEST_CONFIG.v1.tokenYDivisibility,
+          schemaVersion: "v1",
           priceBounds: TEST_CONFIG.tightPriceBounds,
         });
 
@@ -218,21 +367,22 @@ describe("OciSwap Liquidity Assets Test", () => {
     console.log("Tight bounds result:", result);
   });
 
-  it("should calculate liquidity assets with wide price bounds", async () => {
+  it.skip("should calculate liquidity assets with wide price bounds", async () => {
     const program = Effect.provide(
       Effect.gen(function* () {
         const getOciswapLiquidityAssetsService =
           yield* GetOciswapLiquidityAssetsService;
 
         const result = yield* getOciswapLiquidityAssetsService({
-          componentAddress: TEST_CONFIG.componentAddress,
+          componentAddress: TEST_CONFIG.v1.componentAddress,
           addresses: [TEST_CONFIG.userAddress],
-          at_ledger_state: { state_version: 321803265 },
-          lpResourceAddress: TEST_CONFIG.lpResourceAddress,
-          tokenXAddress: TEST_CONFIG.tokenXAddress,
-          tokenYAddress: TEST_CONFIG.tokenYAddress,
-          tokenXDivisibility: TEST_CONFIG.tokenXDivisibility,
-          tokenYDivisibility: TEST_CONFIG.tokenYDivisibility,
+          at_ledger_state: { state_version: 328823647 },
+          lpResourceAddress: TEST_CONFIG.v1.lpResourceAddress,
+          tokenXAddress: TEST_CONFIG.v1.tokenXAddress,
+          tokenYAddress: TEST_CONFIG.v1.tokenYAddress,
+          tokenXDivisibility: TEST_CONFIG.v1.tokenXDivisibility,
+          tokenYDivisibility: TEST_CONFIG.v1.tokenYDivisibility,
+          schemaVersion: "v1",
           priceBounds: TEST_CONFIG.widePriceBounds,
         });
 
@@ -263,20 +413,20 @@ describe("OciSwap Liquidity Assets Test", () => {
     console.log("Wide bounds result:", result);
   });
 
-  it("should show position details for debugging", async () => {
+  it.skip("should show position details for debugging", async () => {
     const program = Effect.provide(
       Effect.gen(function* () {
         const getOciswapLiquidityClaimsService =
           yield* GetOciswapLiquidityClaimsService;
 
         const positionDetails = yield* getOciswapLiquidityClaimsService({
-          lpResourceAddress: TEST_CONFIG.lpResourceAddress,
-          nonFungibleLocalIds: [TEST_CONFIG.nftId],
-          at_ledger_state: { state_version: 321803265 },
+          lpResourceAddress: TEST_CONFIG.v1.lpResourceAddress,
+          nonFungibleLocalIds: [TEST_CONFIG.v1.nftId],
+          at_ledger_state: { state_version: 328823647 },
         });
 
         console.log("=== POSITION DETAILS DEBUG ===");
-        console.log("NFT ID:", TEST_CONFIG.nftId);
+        console.log("NFT ID:", TEST_CONFIG.v1.nftId);
         console.log(
           "Position details:",
           JSON.stringify(positionDetails, null, 2)
@@ -292,7 +442,7 @@ describe("OciSwap Liquidity Assets Test", () => {
     console.log("Position details:", result);
   });
 
-  it("should calculate liquidity assets without price bounds (everything in bounds)", async () => {
+  it.skip("should calculate liquidity assets without price bounds (everything in bounds)", async () => {
     const program = Effect.provide(
       Effect.gen(function* () {
         const getOciswapLiquidityAssetsService =
@@ -303,19 +453,20 @@ describe("OciSwap Liquidity Assets Test", () => {
           yield* GetNonFungibleBalanceService;
         const nonFungibleBalance = yield* getNonFungibleBalanceService({
           addresses: [TEST_CONFIG.userAddress],
-          at_ledger_state: { state_version: 321803265 },
+          at_ledger_state: { state_version: 328823647 },
         });
 
         const result = yield* getOciswapLiquidityAssetsService({
-          componentAddress: TEST_CONFIG.componentAddress,
+          componentAddress: TEST_CONFIG.v1.componentAddress,
           addresses: [TEST_CONFIG.userAddress],
-          at_ledger_state: { state_version: 321803265 },
+          at_ledger_state: { state_version: 328823647 },
           nonFungibleBalance,
-          lpResourceAddress: TEST_CONFIG.lpResourceAddress,
-          tokenXAddress: TEST_CONFIG.tokenXAddress,
-          tokenYAddress: TEST_CONFIG.tokenYAddress,
-          tokenXDivisibility: TEST_CONFIG.tokenXDivisibility,
-          tokenYDivisibility: TEST_CONFIG.tokenYDivisibility,
+          lpResourceAddress: TEST_CONFIG.v1.lpResourceAddress,
+          tokenXAddress: TEST_CONFIG.v1.tokenXAddress,
+          tokenYAddress: TEST_CONFIG.v1.tokenYAddress,
+          tokenXDivisibility: TEST_CONFIG.v1.tokenXDivisibility,
+          tokenYDivisibility: TEST_CONFIG.v1.tokenYDivisibility,
+          schemaVersion: "v1",
           // No priceBounds - everything should be in bounds
         });
 
@@ -354,7 +505,7 @@ describe("OciSwap Liquidity Assets Test", () => {
     console.log("No bounds result:", result);
   });
 
-  it("should test tick math utilities", async () => {
+  it.skip("should test tick math utilities", async () => {
     const { tickToPriceSqrt, removableAmounts } = await import(
       "./tickCalculator"
     );

--- a/packages/api/src/common/dapps/ociswap/getOciswapLiquidityAssets.test.ts
+++ b/packages/api/src/common/dapps/ociswap/getOciswapLiquidityAssets.test.ts
@@ -9,7 +9,7 @@ import {
   GetOciswapLiquidityClaimsService,
 } from "./getOciswapLiquidityClaims";
 import { GatewayApiClientLive } from "../../gateway/gatewayApiClient";
-import { EntityNonFungibleDataLive } from "../../gateway/entityNonFungiblesData";
+
 import { GetComponentStateLive } from "../../gateway/getComponentState";
 import {
   GetNonFungibleBalanceLive,
@@ -19,6 +19,7 @@ import { GetNftResourceManagersLive } from "../../gateway/getNftResourceManagers
 import { GetEntityDetailsServiceLive } from "../../gateway/getEntityDetails";
 import { EntityNonFungiblesPageLive } from "../../gateway/entityNonFungiblesPage";
 import { GetNonFungibleIdsLive } from "../../gateway/getNonFungibleIds";
+import { EntityNonFungibleDataService } from "../../gateway/entityNonFungiblesData";
 
 const TEST_CONFIG = {
   // V1 Pool (xUSDC/XRD)
@@ -80,7 +81,7 @@ const getEntityDetailsLive = GetEntityDetailsServiceLive.pipe(
   Layer.provide(gatewayApiClientLive)
 );
 
-const entityNonFungibleDataLive = EntityNonFungibleDataLive.pipe(
+const entityNonFungibleDataLive = EntityNonFungibleDataService.Default.pipe(
   Layer.provide(gatewayApiClientLive)
 );
 

--- a/packages/api/src/common/dapps/ociswap/getOciswapResourcePoolPositions.test.ts
+++ b/packages/api/src/common/dapps/ociswap/getOciswapResourcePoolPositions.test.ts
@@ -49,7 +49,7 @@ describe("GetOciswapResourcePoolPositionsService", () => {
     const program = Effect.gen(function* () {
       const service = yield* GetOciswapResourcePoolPositionsService;
 
-      const result = yield* service.getOciswapResourcePoolPositions({
+      const result = yield* service.run({
         accountAddresses: [TEST_ACCOUNT_ADDRESS],
         at_ledger_state: { state_version: TEST_STATE_VERSION },
         poolType: "flexPools",
@@ -88,8 +88,6 @@ describe("GetOciswapResourcePoolPositionsService", () => {
           expect(item.yToken).toHaveProperty("totalAmount");
           expect(item.yToken).toHaveProperty("amountInBounds");
           expect(item.yToken).toHaveProperty("resourceAddress");
-
-          expect(typeof item.isActive).toBe("boolean");
         }
       }
     }
@@ -101,7 +99,7 @@ describe("GetOciswapResourcePoolPositionsService", () => {
     const program = Effect.gen(function* () {
       const service = yield* GetOciswapResourcePoolPositionsService;
 
-      const result = yield* service.getOciswapResourcePoolPositions({
+      const result = yield* service.run({
         accountAddresses: [TEST_ACCOUNT_ADDRESS],
         at_ledger_state: { state_version: TEST_STATE_VERSION },
         poolType: "basicPools",
@@ -137,8 +135,6 @@ describe("GetOciswapResourcePoolPositionsService", () => {
           expect(item.yToken).toHaveProperty("totalAmount");
           expect(item.yToken).toHaveProperty("amountInBounds");
           expect(item.yToken).toHaveProperty("resourceAddress");
-
-          expect(typeof item.isActive).toBe("boolean");
         }
       }
     }
@@ -151,7 +147,7 @@ describe("GetOciswapResourcePoolPositionsService", () => {
       const service = yield* GetOciswapResourcePoolPositionsService;
 
       // Test with an account that likely has no positions
-      const result = yield* service.getOciswapResourcePoolPositions({
+      const result = yield* service.run({
         accountAddresses: [
           "account_rdx12y528ccdmqge0dgw9ce3vg30vyhax5ynpwakvzafrzzg69texgpe60",
         ], // Example empty account

--- a/packages/api/src/common/dapps/ociswap/getOciswapResourcePoolPositions.test.ts
+++ b/packages/api/src/common/dapps/ociswap/getOciswapResourcePoolPositions.test.ts
@@ -1,0 +1,180 @@
+import { Effect, Layer } from "effect";
+import { describe, it, expect } from "vitest";
+import {
+  GetOciswapResourcePoolPositionsService,
+  GetOciswapResourcePoolPositionsLive,
+} from "./getOciswapResourcePoolPositions";
+import { GetFungibleBalanceLive } from "../../gateway/getFungibleBalance";
+import { GetResourcePoolUnitsLive } from "../../resource-pool/getResourcePoolUnits";
+import { GetEntityDetailsServiceLive } from "../../gateway/getEntityDetails";
+import { GatewayApiClientLive } from "../../gateway/gatewayApiClient";
+import { EntityFungiblesPageLive } from "../../gateway/entityFungiblesPage";
+
+// Test configuration
+const TEST_ACCOUNT_ADDRESS =
+  "account_rdx12xl2meqtelz47mwp3nzd72jkwyallg5yxr9hkc75ac4qztsxulfpew";
+const TEST_STATE_VERSION = 328823647;
+
+// Create a test layer that provides all dependencies
+const gatewayApiClientLive = GatewayApiClientLive;
+
+const getEntityDetailsServiceLive = GetEntityDetailsServiceLive.pipe(
+  Layer.provide(gatewayApiClientLive)
+);
+
+const entityFungiblesPageServiceLive = EntityFungiblesPageLive.pipe(
+  Layer.provide(gatewayApiClientLive)
+);
+
+const getFungibleBalanceLive = GetFungibleBalanceLive.pipe(
+  Layer.provide(gatewayApiClientLive),
+  Layer.provide(entityFungiblesPageServiceLive)
+);
+
+const getResourcePoolUnitsLive = GetResourcePoolUnitsLive.pipe(
+  Layer.provide(getFungibleBalanceLive),
+  Layer.provide(getEntityDetailsServiceLive)
+);
+
+const getOciswapResourcePoolPositionsLive =
+  GetOciswapResourcePoolPositionsLive.pipe(
+    Layer.provide(getFungibleBalanceLive),
+    Layer.provide(getResourcePoolUnitsLive)
+  );
+
+const testLayer = getOciswapResourcePoolPositionsLive;
+
+describe("GetOciswapResourcePoolPositionsService", () => {
+  it("should fetch FlexPool positions correctly", async () => {
+    const program = Effect.gen(function* () {
+      const service = yield* GetOciswapResourcePoolPositionsService;
+
+      const result = yield* service.getOciswapResourcePoolPositions({
+        accountAddresses: [TEST_ACCOUNT_ADDRESS],
+        at_ledger_state: { state_version: TEST_STATE_VERSION },
+        poolType: "flexPools",
+      });
+
+      return result;
+    });
+
+    const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+    // Verify the structure
+    expect(Array.isArray(result)).toBe(true);
+
+    // Each result should have pool and result properties
+    for (const poolData of result) {
+      expect(poolData).toHaveProperty("pool");
+      expect(poolData).toHaveProperty("result");
+      expect(Array.isArray(poolData.result)).toBe(true);
+
+      // Each result should have address and items
+      for (const accountData of poolData.result) {
+        expect(accountData).toHaveProperty("address");
+        expect(accountData).toHaveProperty("items");
+        expect(Array.isArray(accountData.items)).toBe(true);
+
+        // If there are items, they should have the correct structure
+        for (const item of accountData.items) {
+          expect(item).toHaveProperty("xToken");
+          expect(item).toHaveProperty("yToken");
+          expect(item).toHaveProperty("isActive");
+
+          expect(item.xToken).toHaveProperty("totalAmount");
+          expect(item.xToken).toHaveProperty("amountInBounds");
+          expect(item.xToken).toHaveProperty("resourceAddress");
+
+          expect(item.yToken).toHaveProperty("totalAmount");
+          expect(item.yToken).toHaveProperty("amountInBounds");
+          expect(item.yToken).toHaveProperty("resourceAddress");
+
+          expect(typeof item.isActive).toBe("boolean");
+        }
+      }
+    }
+
+    console.log("FlexPool positions result:", JSON.stringify(result, null, 2));
+  });
+
+  it("should fetch BasicPool positions correctly", async () => {
+    const program = Effect.gen(function* () {
+      const service = yield* GetOciswapResourcePoolPositionsService;
+
+      const result = yield* service.getOciswapResourcePoolPositions({
+        accountAddresses: [TEST_ACCOUNT_ADDRESS],
+        at_ledger_state: { state_version: TEST_STATE_VERSION },
+        poolType: "basicPools",
+      });
+
+      return result;
+    });
+
+    const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+    // Verify the structure (same as FlexPools)
+    expect(Array.isArray(result)).toBe(true);
+
+    for (const poolData of result) {
+      expect(poolData).toHaveProperty("pool");
+      expect(poolData).toHaveProperty("result");
+      expect(Array.isArray(poolData.result)).toBe(true);
+
+      for (const accountData of poolData.result) {
+        expect(accountData).toHaveProperty("address");
+        expect(accountData).toHaveProperty("items");
+        expect(Array.isArray(accountData.items)).toBe(true);
+
+        for (const item of accountData.items) {
+          expect(item).toHaveProperty("xToken");
+          expect(item).toHaveProperty("yToken");
+          expect(item).toHaveProperty("isActive");
+
+          expect(item.xToken).toHaveProperty("totalAmount");
+          expect(item.xToken).toHaveProperty("amountInBounds");
+          expect(item.xToken).toHaveProperty("resourceAddress");
+
+          expect(item.yToken).toHaveProperty("totalAmount");
+          expect(item.yToken).toHaveProperty("amountInBounds");
+          expect(item.yToken).toHaveProperty("resourceAddress");
+
+          expect(typeof item.isActive).toBe("boolean");
+        }
+      }
+    }
+
+    console.log("BasicPool positions result:", JSON.stringify(result, null, 2));
+  });
+
+  it("should handle empty results gracefully", async () => {
+    const program = Effect.gen(function* () {
+      const service = yield* GetOciswapResourcePoolPositionsService;
+
+      // Test with an account that likely has no positions
+      const result = yield* service.getOciswapResourcePoolPositions({
+        accountAddresses: [
+          "account_rdx12y528ccdmqge0dgw9ce3vg30vyhax5ynpwakvzafrzzg69texgpe60",
+        ], // Example empty account
+        at_ledger_state: { state_version: 328823647 },
+        poolType: "flexPools",
+      });
+
+      return result;
+    });
+
+    const result = await Effect.runPromise(Effect.provide(program, testLayer));
+
+    // Should still return proper structure even with no positions
+    expect(Array.isArray(result)).toBe(true);
+
+    for (const poolData of result) {
+      expect(poolData).toHaveProperty("pool");
+      expect(poolData).toHaveProperty("result");
+      expect(Array.isArray(poolData.result)).toBe(true);
+
+      // Should have one result per account address, even if empty
+      expect(poolData.result).toHaveLength(1);
+      expect(poolData.result[0].items).toHaveLength(0);
+    }
+  });
+});

--- a/packages/api/src/common/dapps/ociswap/getOciswapResourcePoolPositions.ts
+++ b/packages/api/src/common/dapps/ociswap/getOciswapResourcePoolPositions.ts
@@ -1,0 +1,223 @@
+import { Effect } from "effect";
+import BigNumber from "bignumber.js";
+
+import {
+  type GetFungibleBalanceOutput,
+  GetFungibleBalanceService,
+} from "../../gateway/getFungibleBalance";
+
+import { OciswapConstants } from "./constants";
+import type { AtLedgerState } from "../../gateway/schemas";
+
+import { GetResourcePoolUnitsService } from "../../resource-pool/getResourcePoolUnits";
+
+export class InvalidResourcePoolError extends Error {
+  readonly _tag = "InvalidResourcePoolError";
+  constructor(error: unknown) {
+    super(
+      `Invalid resource pool error: ${error instanceof Error ? error.message : error}`
+    );
+  }
+}
+
+export type OciswapResourcePoolLiquidityAsset = {
+  xToken: {
+    totalAmount: string;
+    amountInBounds: string;
+    resourceAddress: string;
+  };
+  yToken: {
+    totalAmount: string;
+    amountInBounds: string;
+    resourceAddress: string;
+  };
+  isActive: boolean;
+};
+
+export type GetOciswapResourcePoolPositionsOutput = {
+  pool:
+    | (typeof OciswapConstants.flexPools)[keyof typeof OciswapConstants.flexPools]
+    | (typeof OciswapConstants.basicPools)[keyof typeof OciswapConstants.basicPools];
+  result: {
+    address: string;
+    items: OciswapResourcePoolLiquidityAsset[];
+  }[];
+}[];
+
+type AccountAddress = string;
+
+export class GetOciswapResourcePoolPositionsService extends Effect.Service<GetOciswapResourcePoolPositionsService>()(
+  "GetOciswapResourcePoolPositionsService",
+  {
+    effect: Effect.gen(function* () {
+      const getFungibleBalanceService = yield* GetFungibleBalanceService;
+      const getResourcePoolUnitsService = yield* GetResourcePoolUnitsService;
+
+      return {
+        getOciswapResourcePoolPositions: Effect.fn(
+          (input: {
+            accountAddresses: string[];
+            at_ledger_state: AtLedgerState;
+            fungibleBalance?: GetFungibleBalanceOutput;
+            poolType?: "flexPools" | "basicPools";
+          }) =>
+            Effect.gen(function* () {
+              const accountBalancesMap = new Map<
+                AccountAddress,
+                OciswapResourcePoolLiquidityAsset[]
+              >();
+
+              // Get pools based on pool type (if not specified, use both)
+              const poolTypes = input.poolType
+                ? [input.poolType]
+                : ["flexPools" as const, "basicPools" as const];
+
+              // Initialize map for all account addresses
+              for (const address of input.accountAddresses) {
+                accountBalancesMap.set(address, []);
+              }
+
+              // Get fungible balances if not provided (only need to do this once)
+              const fungibleBalance =
+                input.fungibleBalance ??
+                (yield* getFungibleBalanceService({
+                  addresses: input.accountAddresses,
+                  at_ledger_state: input.at_ledger_state,
+                }));
+
+              const allPoolOutputResults = [];
+
+              // Process each pool type
+              for (const poolType of poolTypes) {
+                const pools =
+                  poolType === "flexPools"
+                    ? OciswapConstants.flexPools
+                    : OciswapConstants.basicPools;
+
+                const allPoolAddresses = Object.values(pools).map(
+                  (pool) => pool.poolAddress
+                );
+
+                // Get pool units for all pools of this type
+                const poolUnitsResults = yield* getResourcePoolUnitsService({
+                  addresses: allPoolAddresses,
+                  at_ledger_state: input.at_ledger_state,
+                });
+
+                // Create a map of pool address to pool configuration
+                const poolConfigMap = new Map();
+                for (const [key, pool] of Object.entries(pools)) {
+                  poolConfigMap.set(pool.poolAddress, { key, ...pool });
+                }
+
+                // Process each pool result for this pool type
+                for (const poolResult of poolUnitsResults) {
+                  const poolConfig = poolConfigMap.get(poolResult.address);
+                  if (!poolConfig) continue;
+
+                  try {
+                    // Process each account's LP tokens for this pool
+                    for (const address of input.accountAddresses) {
+                      const accountLpBalance = fungibleBalance
+                        .find((balance) => balance.address === address)
+                        ?.fungibleResources.find(
+                          (item) =>
+                            item.resourceAddress ===
+                            poolConfig.lpResourceAddress
+                        );
+
+                      if (
+                        !accountLpBalance ||
+                        new BigNumber(accountLpBalance.amount).lte(0)
+                      ) {
+                        continue;
+                      }
+
+                      // Calculate user's amounts for each token in the pool
+                      const lpBalance = new BigNumber(accountLpBalance.amount);
+                      const contributedAmounts = poolResult.poolResources;
+                      if (contributedAmounts.length !== 2) {
+                        return yield* Effect.fail(
+                          new InvalidResourcePoolError(
+                            `Pool must have exactly 2 tokens, found ${contributedAmounts.length}`
+                          )
+                        );
+                      }
+                      const [token1, token2] = contributedAmounts as [
+                        (typeof contributedAmounts)[0],
+                        (typeof contributedAmounts)[1],
+                      ];
+
+                      // poolUnitValue already represents the value per LP token, so just multiply by LP balance
+                      const token1Amount =
+                        token1.poolUnitValue.multipliedBy(lpBalance);
+                      const token2Amount =
+                        token2.poolUnitValue.multipliedBy(lpBalance);
+
+                      // Create OciswapLiquidityAsset format (liquidity is always within range for pool units)
+                      const liquidityAsset: OciswapResourcePoolLiquidityAsset =
+                        {
+                          xToken: {
+                            totalAmount: token1Amount.toString(),
+                            amountInBounds: token1Amount.toString(), // Pool units are always "in bounds"
+                            resourceAddress: token1.resourceAddress,
+                          },
+                          yToken: {
+                            totalAmount: token2Amount.toString(),
+                            amountInBounds: token2Amount.toString(), // Pool units are always "in bounds"
+                            resourceAddress: token2.resourceAddress,
+                          },
+                          isActive: true,
+                        };
+
+                      // Add to user's positions
+                      const accountPositions =
+                        accountBalancesMap.get(address) ?? [];
+                      accountPositions.push(liquidityAsset);
+                      accountBalancesMap.set(address, accountPositions);
+                    }
+                  } catch (error) {
+                    return yield* Effect.fail(
+                      new InvalidResourcePoolError(error)
+                    );
+                  }
+                }
+
+                // Convert map to output format grouped by pool (similar to regular Ociswap)
+                for (const [_key, pool] of Object.entries(pools)) {
+                  const poolAccountResults = input.accountAddresses.map(
+                    (address) => {
+                      const accountPositions =
+                        accountBalancesMap.get(address) ?? [];
+                      // Filter positions for this specific pool
+                      const poolSpecificPositions = accountPositions.filter(
+                        (item) =>
+                          (item.xToken.resourceAddress === pool.token_x &&
+                            item.yToken.resourceAddress === pool.token_y) ||
+                          (item.xToken.resourceAddress === pool.token_y &&
+                            item.yToken.resourceAddress === pool.token_x)
+                      );
+                      return {
+                        address,
+                        items: poolSpecificPositions,
+                      };
+                    }
+                  );
+
+                  allPoolOutputResults.push({
+                    pool,
+                    result: poolAccountResults,
+                  });
+                }
+              }
+
+              return allPoolOutputResults;
+            })
+        ),
+      };
+    }),
+  }
+) {}
+
+export const GetOciswapResourcePoolPositionsLive =
+  GetOciswapResourcePoolPositionsService.Default;

--- a/packages/api/src/common/dapps/ociswap/getOciswapResourcePoolPositions.ts
+++ b/packages/api/src/common/dapps/ociswap/getOciswapResourcePoolPositions.ts
@@ -31,7 +31,6 @@ export type OciswapResourcePoolLiquidityAsset = {
     amountInBounds: string;
     resourceAddress: string;
   };
-  isActive: boolean;
 };
 
 export type GetOciswapResourcePoolPositionsOutput = {
@@ -54,166 +53,161 @@ export class GetOciswapResourcePoolPositionsService extends Effect.Service<GetOc
       const getResourcePoolUnitsService = yield* GetResourcePoolUnitsService;
 
       return {
-        getOciswapResourcePoolPositions: Effect.fn(
-          (input: {
-            accountAddresses: string[];
-            at_ledger_state: AtLedgerState;
-            fungibleBalance?: GetFungibleBalanceOutput;
-            poolType?: "flexPools" | "basicPools";
-          }) =>
-            Effect.gen(function* () {
-              const accountBalancesMap = new Map<
-                AccountAddress,
-                OciswapResourcePoolLiquidityAsset[]
-              >();
+        run: (input: {
+          accountAddresses: string[];
+          at_ledger_state: AtLedgerState;
+          fungibleBalance?: GetFungibleBalanceOutput;
+          poolType?: "flexPools" | "basicPools";
+        }) =>
+          Effect.gen(function* () {
+            const accountBalancesMap = new Map<
+              AccountAddress,
+              OciswapResourcePoolLiquidityAsset[]
+            >();
 
-              // Get pools based on pool type (if not specified, use both)
-              const poolTypes = input.poolType
-                ? [input.poolType]
-                : ["flexPools" as const, "basicPools" as const];
+            // Get pools based on pool type (if not specified, use both)
+            const poolTypes = input.poolType
+              ? [input.poolType]
+              : ["flexPools" as const, "basicPools" as const];
 
-              // Initialize map for all account addresses
-              for (const address of input.accountAddresses) {
-                accountBalancesMap.set(address, []);
+            // Initialize map for all account addresses
+            for (const address of input.accountAddresses) {
+              accountBalancesMap.set(address, []);
+            }
+
+            // Get fungible balances if not provided (only need to do this once)
+            const fungibleBalance =
+              input.fungibleBalance ??
+              (yield* getFungibleBalanceService({
+                addresses: input.accountAddresses,
+                at_ledger_state: input.at_ledger_state,
+              }));
+
+            const allPoolOutputResults = [];
+
+            // Process each pool type
+            for (const poolType of poolTypes) {
+              const pools =
+                poolType === "flexPools"
+                  ? OciswapConstants.flexPools
+                  : OciswapConstants.basicPools;
+
+              const allPoolAddresses = Object.values(pools).map(
+                (pool) => pool.poolAddress
+              );
+
+              // Get pool units for all pools of this type
+              const poolUnitsResults = yield* getResourcePoolUnitsService({
+                addresses: allPoolAddresses,
+                at_ledger_state: input.at_ledger_state,
+              });
+
+              // Create a map of pool address to pool configuration
+              const poolConfigMap = new Map();
+              for (const [key, pool] of Object.entries(pools)) {
+                poolConfigMap.set(pool.poolAddress, { key, ...pool });
               }
 
-              // Get fungible balances if not provided (only need to do this once)
-              const fungibleBalance =
-                input.fungibleBalance ??
-                (yield* getFungibleBalanceService({
-                  addresses: input.accountAddresses,
-                  at_ledger_state: input.at_ledger_state,
-                }));
+              // Process each pool result for this pool type
+              for (const poolResult of poolUnitsResults) {
+                const poolConfig = poolConfigMap.get(poolResult.address);
+                if (!poolConfig) continue;
 
-              const allPoolOutputResults = [];
+                try {
+                  // Process each account's LP tokens for this pool
+                  for (const address of input.accountAddresses) {
+                    const accountLpBalance = fungibleBalance
+                      .find((balance) => balance.address === address)
+                      ?.fungibleResources.find(
+                        (item) =>
+                          item.resourceAddress === poolConfig.lpResourceAddress
+                      );
 
-              // Process each pool type
-              for (const poolType of poolTypes) {
-                const pools =
-                  poolType === "flexPools"
-                    ? OciswapConstants.flexPools
-                    : OciswapConstants.basicPools;
+                    if (
+                      !accountLpBalance ||
+                      new BigNumber(accountLpBalance.amount).lte(0)
+                    ) {
+                      continue;
+                    }
 
-                const allPoolAddresses = Object.values(pools).map(
-                  (pool) => pool.poolAddress
+                    // Calculate user's amounts for each token in the pool
+                    const lpBalance = new BigNumber(accountLpBalance.amount);
+                    const contributedAmounts = poolResult.poolResources;
+                    if (contributedAmounts.length !== 2) {
+                      return yield* Effect.fail(
+                        new InvalidResourcePoolError(
+                          `Pool must have exactly 2 tokens, found ${contributedAmounts.length}`
+                        )
+                      );
+                    }
+                    const [token1, token2] = contributedAmounts as [
+                      (typeof contributedAmounts)[0],
+                      (typeof contributedAmounts)[1],
+                    ];
+
+                    // poolUnitValue already represents the value per LP token, so just multiply by LP balance
+                    const token1Amount =
+                      token1.poolUnitValue.multipliedBy(lpBalance);
+                    const token2Amount =
+                      token2.poolUnitValue.multipliedBy(lpBalance);
+
+                    // Create OciswapLiquidityAsset format (liquidity is always within range for pool units)
+                    const liquidityAsset: OciswapResourcePoolLiquidityAsset = {
+                      xToken: {
+                        totalAmount: token1Amount.toString(),
+                        amountInBounds: token1Amount.toString(), // Pool units are always "in bounds"
+                        resourceAddress: token1.resourceAddress,
+                      },
+                      yToken: {
+                        totalAmount: token2Amount.toString(),
+                        amountInBounds: token2Amount.toString(), // Pool units are always "in bounds"
+                        resourceAddress: token2.resourceAddress,
+                      },
+                    };
+
+                    // Add to user's positions
+                    const accountPositions =
+                      accountBalancesMap.get(address) ?? [];
+                    accountPositions.push(liquidityAsset);
+                    accountBalancesMap.set(address, accountPositions);
+                  }
+                } catch (error) {
+                  return yield* Effect.fail(
+                    new InvalidResourcePoolError(error)
+                  );
+                }
+              }
+
+              // Convert map to output format grouped by pool (similar to regular Ociswap)
+              for (const [_key, pool] of Object.entries(pools)) {
+                const poolAccountResults = input.accountAddresses.map(
+                  (address) => {
+                    const accountPositions =
+                      accountBalancesMap.get(address) ?? [];
+                    // Filter positions for this specific pool
+                    const poolSpecificPositions = accountPositions.filter(
+                      (item) =>
+                        (item.xToken.resourceAddress === pool.token_x &&
+                          item.yToken.resourceAddress === pool.token_y) ||
+                        (item.xToken.resourceAddress === pool.token_y &&
+                          item.yToken.resourceAddress === pool.token_x)
+                    );
+                    return {
+                      address,
+                      items: poolSpecificPositions,
+                    };
+                  }
                 );
 
-                // Get pool units for all pools of this type
-                const poolUnitsResults = yield* getResourcePoolUnitsService({
-                  addresses: allPoolAddresses,
-                  at_ledger_state: input.at_ledger_state,
+                allPoolOutputResults.push({
+                  pool,
+                  result: poolAccountResults,
                 });
-
-                // Create a map of pool address to pool configuration
-                const poolConfigMap = new Map();
-                for (const [key, pool] of Object.entries(pools)) {
-                  poolConfigMap.set(pool.poolAddress, { key, ...pool });
-                }
-
-                // Process each pool result for this pool type
-                for (const poolResult of poolUnitsResults) {
-                  const poolConfig = poolConfigMap.get(poolResult.address);
-                  if (!poolConfig) continue;
-
-                  try {
-                    // Process each account's LP tokens for this pool
-                    for (const address of input.accountAddresses) {
-                      const accountLpBalance = fungibleBalance
-                        .find((balance) => balance.address === address)
-                        ?.fungibleResources.find(
-                          (item) =>
-                            item.resourceAddress ===
-                            poolConfig.lpResourceAddress
-                        );
-
-                      if (
-                        !accountLpBalance ||
-                        new BigNumber(accountLpBalance.amount).lte(0)
-                      ) {
-                        continue;
-                      }
-
-                      // Calculate user's amounts for each token in the pool
-                      const lpBalance = new BigNumber(accountLpBalance.amount);
-                      const contributedAmounts = poolResult.poolResources;
-                      if (contributedAmounts.length !== 2) {
-                        return yield* Effect.fail(
-                          new InvalidResourcePoolError(
-                            `Pool must have exactly 2 tokens, found ${contributedAmounts.length}`
-                          )
-                        );
-                      }
-                      const [token1, token2] = contributedAmounts as [
-                        (typeof contributedAmounts)[0],
-                        (typeof contributedAmounts)[1],
-                      ];
-
-                      // poolUnitValue already represents the value per LP token, so just multiply by LP balance
-                      const token1Amount =
-                        token1.poolUnitValue.multipliedBy(lpBalance);
-                      const token2Amount =
-                        token2.poolUnitValue.multipliedBy(lpBalance);
-
-                      // Create OciswapLiquidityAsset format (liquidity is always within range for pool units)
-                      const liquidityAsset: OciswapResourcePoolLiquidityAsset =
-                        {
-                          xToken: {
-                            totalAmount: token1Amount.toString(),
-                            amountInBounds: token1Amount.toString(), // Pool units are always "in bounds"
-                            resourceAddress: token1.resourceAddress,
-                          },
-                          yToken: {
-                            totalAmount: token2Amount.toString(),
-                            amountInBounds: token2Amount.toString(), // Pool units are always "in bounds"
-                            resourceAddress: token2.resourceAddress,
-                          },
-                          isActive: true,
-                        };
-
-                      // Add to user's positions
-                      const accountPositions =
-                        accountBalancesMap.get(address) ?? [];
-                      accountPositions.push(liquidityAsset);
-                      accountBalancesMap.set(address, accountPositions);
-                    }
-                  } catch (error) {
-                    return yield* Effect.fail(
-                      new InvalidResourcePoolError(error)
-                    );
-                  }
-                }
-
-                // Convert map to output format grouped by pool (similar to regular Ociswap)
-                for (const [_key, pool] of Object.entries(pools)) {
-                  const poolAccountResults = input.accountAddresses.map(
-                    (address) => {
-                      const accountPositions =
-                        accountBalancesMap.get(address) ?? [];
-                      // Filter positions for this specific pool
-                      const poolSpecificPositions = accountPositions.filter(
-                        (item) =>
-                          (item.xToken.resourceAddress === pool.token_x &&
-                            item.yToken.resourceAddress === pool.token_y) ||
-                          (item.xToken.resourceAddress === pool.token_y &&
-                            item.yToken.resourceAddress === pool.token_x)
-                      );
-                      return {
-                        address,
-                        items: poolSpecificPositions,
-                      };
-                    }
-                  );
-
-                  allPoolOutputResults.push({
-                    pool,
-                    result: poolAccountResults,
-                  });
-                }
               }
+            }
 
-              return allPoolOutputResults;
-            })
-        ),
+            return allPoolOutputResults;
+          }),
       };
     }),
   }

--- a/packages/api/src/common/dapps/ociswap/schemas.ts
+++ b/packages/api/src/common/dapps/ociswap/schemas.ts
@@ -4,7 +4,7 @@ export const TickOutside = s.struct({
   index: s.number(),
   x_fee: s.decimal(),
   y_fee: s.decimal(),
-  seconds: s.number()
+  seconds: s.number(),
 });
 
 export const SwapEvent = s.struct({
@@ -34,13 +34,13 @@ export const Node = s.struct({
   parent: s.option(s.number()),
   next: s.option(s.number()),
   prev: s.option(s.number()),
-  balance_factor: s.number()
+  balance_factor: s.number(),
 });
 
 export const AvlTree = s.struct({
   root: s.option(s.number()),
   store: s.internalAddress(),
-  store_cache: s.map({ key: s.number(), value: Node })
+  store_cache: s.map({ key: s.number(), value: Node }),
 });
 
 export const HookCalls = s.struct({
@@ -51,7 +51,7 @@ export const HookCalls = s.struct({
   before_swap: s.tuple([s.string(), s.array(s.address())]),
   after_swap: s.tuple([s.string(), s.array(s.address())]),
   before_remove_liquidity: s.tuple([s.string(), s.array(s.address())]),
-  after_remove_liquidity: s.tuple([s.string(), s.array(s.address())])
+  after_remove_liquidity: s.tuple([s.string(), s.array(s.address())]),
 });
 
 export const PrecisionPool = s.struct({
@@ -97,3 +97,77 @@ export const LiquidityPosition = s.struct({
 
 export type PrecisionPool = s.infer<typeof PrecisionPool>;
 export type LiquidityPosition = s.infer<typeof LiquidityPosition>;
+
+// Non-precision pool schemas
+
+export const BasicPoolSwapEvent = s.struct({
+  input_address: s.address(),
+  input_amount: s.decimal(),
+  output_address: s.address(),
+  output_amount: s.decimal(),
+  input_fee_lp: s.decimal(),
+});
+
+export type BasicPoolSwapEvent = s.infer<typeof BasicPoolSwapEvent>;
+
+export const FlexPoolSwapEvent = s.struct({
+  input_address: s.address(),
+  input_amount: s.decimal(),
+  input_gross_amount: s.decimal(),
+  input_fee_lp: s.decimal(),
+  input_fee_protocol: s.decimal(),
+  output_address: s.address(),
+  output_amount: s.decimal(),
+  output_return_amount: s.decimal(),
+  price_sqrt: s.decimal(),
+});
+
+export type FlexPoolSwapEvent = s.infer<typeof FlexPoolSwapEvent>;
+
+export const SubObservations = s.struct({
+  price_sqrt_sum: s.decimal(),
+  price_sqrt_last: s.decimal(),
+  last_updated: s.instant(),
+  initialization: s.option(s.instant()),
+});
+
+export const Oracle = s.struct({
+  observations: s.internalAddress(),
+  last_observation_index: s.option(s.number()),
+  observations_stored: s.number(),
+  sub_observations: s.option(SubObservations),
+  observations_limit: s.number(),
+});
+
+export const PrecisionPoolV2 = s.struct({
+  pool_address: s.address(),
+  x_liquidity: s.internalAddress(),
+  y_liquidity: s.internalAddress(),
+  x_fees: s.internalAddress(),
+  y_fees: s.internalAddress(),
+  tick_spacing: s.number(),
+  max_liquidity_per_tick: s.decimal(),
+  price_sqrt: s.decimal(),
+  active_tick: s.option(s.number()),
+  active_liquidity: s.decimal(),
+  lp_manager: s.address(),
+  lp_counter: s.number(),
+  ticks: AvlTree,
+  registry: s.address(),
+  next_sync_time: s.number(),
+  input_fee_rate: s.decimal(),
+  fee_protocol_share: s.decimal(),
+  x_lp_fee: s.decimal(),
+  y_lp_fee: s.decimal(),
+  x_protocol_fee: s.internalAddress(),
+  y_protocol_fee: s.internalAddress(),
+  instantiated_at: s.number(),
+  flash_manager: s.address(),
+  flash_loan_fee_rate: s.decimal(),
+  hooks: s.map({ key: s.tuple([s.address(), s.string()]), value: s.address() }),
+  hook_calls: HookCalls,
+  hook_badges: s.map({ key: s.address(), value: s.internalAddress() }),
+  oracle: Oracle,
+});
+
+export type PrecisionPoolV2 = s.infer<typeof PrecisionPoolV2>;

--- a/packages/api/src/incentives/account-balance/aggregateAccountBalance.ts
+++ b/packages/api/src/incentives/account-balance/aggregateAccountBalance.ts
@@ -51,7 +51,8 @@ export const AggregateAccountBalanceLive = Layer.effect(
       yield* AggregateRootFinancePositionsService;
     const aggregateDefiPlazaPositionsService =
       yield* AggregateDefiPlazaPositionsService;
-    const aggregateSurgePositionsService = yield* AggregateSurgePositionsService;
+    const aggregateSurgePositionsService =
+      yield* AggregateSurgePositionsService;
 
     return (input) =>
       Effect.gen(function* () {
@@ -87,10 +88,11 @@ export const AggregateAccountBalanceLive = Layer.effect(
                   accountBalance,
                   timestamp: input.timestamp,
                 });
-              const surgePositions = yield* aggregateSurgePositionsService.aggregateSurgePositions({
-                accountBalance,
-                timestamp: input.timestamp,
-              });
+              const surgePositions =
+                yield* aggregateSurgePositionsService.aggregateSurgePositions({
+                  accountBalance,
+                  timestamp: input.timestamp,
+                });
 
               return {
                 timestamp: input.timestamp,

--- a/packages/api/src/incentives/account-balance/aggregateCaviarninePositions.ts
+++ b/packages/api/src/incentives/account-balance/aggregateCaviarninePositions.ts
@@ -58,16 +58,16 @@ export const AggregateCaviarninePositionsLive = Layer.effect(
 
           // Get token info including XRD derivative status
           const xTokenInfo =
-            yield* addressValidationService.getTokenNameAndXrdStatus(
+            yield* addressValidationService.getTokenNameAndNativeAssetStatus(
               xToken.resourceAddress
             );
           const yTokenInfo =
-            yield* addressValidationService.getTokenNameAndXrdStatus(
+            yield* addressValidationService.getTokenNameAndNativeAssetStatus(
               yToken.resourceAddress
             );
 
-          const isXTokenXrdDerivative = xTokenInfo.isXrdDerivative;
-          const isYTokenXrdDerivative = yTokenInfo.isXrdDerivative;
+          const isXTokenNativeAsset = xTokenInfo.isNativeAsset;
+          const isYTokenNativeAsset = yTokenInfo.isNativeAsset;
           const xTokenName = xTokenInfo.name;
           const yTokenName = yTokenInfo.name;
 
@@ -115,13 +115,13 @@ export const AggregateCaviarninePositionsLive = Layer.effect(
             : new BigNumber(0);
 
           // Split values based on XRD derivative status
-          const totalNonXrdDerivativeUsdValue = new BigNumber(0)
-            .plus(isXTokenXrdDerivative ? 0 : xTokenUsdValue)
-            .plus(isYTokenXrdDerivative ? 0 : yTokenUsdValue);
+          const totalWrappedAssetUsdValue = new BigNumber(0)
+            .plus(isXTokenNativeAsset ? 0 : xTokenUsdValue)
+            .plus(isYTokenNativeAsset ? 0 : yTokenUsdValue);
 
-          const totalXrdDerivativeUsdValue = new BigNumber(0)
-            .plus(isXTokenXrdDerivative ? xTokenUsdValue : 0)
-            .plus(isYTokenXrdDerivative ? yTokenUsdValue : 0);
+          const totalNativeAssetUsdValue = new BigNumber(0)
+            .plus(isXTokenNativeAsset ? xTokenUsdValue : 0)
+            .plus(isYTokenNativeAsset ? yTokenUsdValue : 0);
 
           // Generate activity IDs based on token pair
           const nonNativeActivityId = `c9_lp_${getPair(
@@ -140,7 +140,7 @@ export const AggregateCaviarninePositionsLive = Layer.effect(
           // Add non-native LP activity (non-XRD derivative tokens only)
           results.push({
             activityId: nonNativeActivityId,
-            usdValue: totalNonXrdDerivativeUsdValue.toString(),
+            usdValue: totalWrappedAssetUsdValue.toString(),
             metadata: {
               tokenPair: getPair(xTokenName as Token, yTokenName as Token),
               baseToken: {
@@ -148,14 +148,14 @@ export const AggregateCaviarninePositionsLive = Layer.effect(
                 amount: totals.totalXToken.toString(),
                 outsidePriceBounds:
                   totals.totalXTokenOutsidePriceBounds.toString(),
-                isXrdOrDerivative: isXTokenXrdDerivative,
+                isNativeAsset: isXTokenNativeAsset,
               },
               quoteToken: {
                 resourceAddress: yToken.resourceAddress,
                 amount: totals.totalYToken.toString(),
                 outsidePriceBounds:
                   totals.totalYTokenOutsidePriceBounds.toString(),
-                isXrdOrDerivative: isYTokenXrdDerivative,
+                isNativeAsset: isYTokenNativeAsset,
               },
             },
           });
@@ -163,7 +163,7 @@ export const AggregateCaviarninePositionsLive = Layer.effect(
           // Add native LP activity (XRD derivatives only)
           results.push({
             activityId: nativeActivityId,
-            usdValue: totalXrdDerivativeUsdValue.toString(),
+            usdValue: totalNativeAssetUsdValue.toString(),
             metadata: {
               tokenPair: getPair(xTokenName as Token, yTokenName as Token),
               baseToken: {
@@ -171,14 +171,14 @@ export const AggregateCaviarninePositionsLive = Layer.effect(
                 amount: totals.totalXToken.toString(),
                 outsidePriceBounds:
                   totals.totalXTokenOutsidePriceBounds.toString(),
-                isXrdOrDerivative: isXTokenXrdDerivative,
+                isNativeAsset: isXTokenNativeAsset,
               },
               quoteToken: {
                 resourceAddress: yToken.resourceAddress,
                 amount: totals.totalYToken.toString(),
                 outsidePriceBounds:
                   totals.totalYTokenOutsidePriceBounds.toString(),
-                isXrdOrDerivative: isYTokenXrdDerivative,
+                isNativeAsset: isYTokenNativeAsset,
               },
             },
           });
@@ -234,12 +234,12 @@ export const AggregateCaviarninePositionsLive = Layer.effect(
             baseToken: {
               resourceAddress: CaviarNineConstants.LSULP.resourceAddress,
               amount: totalLsulpAmount.toString(),
-              isXrdOrDerivative: true,
+              isNativeAsset: true,
             },
             quoteToken: {
               resourceAddress: Assets.Fungible.XRD,
               amount: totalXrdAmount.toString(),
-              isXrdOrDerivative: true,
+              isNativeAsset: true,
             },
           },
         });
@@ -249,11 +249,11 @@ export const AggregateCaviarninePositionsLive = Layer.effect(
           CaviarNineConstants.shapeLiquidityPools
         )) {
           const xTokenInfo =
-            yield* addressValidationService.getTokenNameAndXrdStatus(
+            yield* addressValidationService.getTokenNameAndNativeAssetStatus(
               pool.token_x
             );
           const yTokenInfo =
-            yield* addressValidationService.getTokenNameAndXrdStatus(
+            yield* addressValidationService.getTokenNameAndNativeAssetStatus(
               pool.token_y
             );
           const nonNativeActivityId = `c9_lp_${getPair(
@@ -266,8 +266,8 @@ export const AggregateCaviarninePositionsLive = Layer.effect(
           )}` as ActivityId;
 
           // Get XRD derivative status from the centralized function
-          const isXTokenXrdDerivative = xTokenInfo.isXrdDerivative;
-          const isYTokenXrdDerivative = yTokenInfo.isXrdDerivative;
+          const isXTokenNativeAsset = xTokenInfo.isNativeAsset;
+          const isYTokenNativeAsset = yTokenInfo.isNativeAsset;
 
           // Add zero entry for non-native LP if not processed
           if (!processedPools.has(nonNativeActivityId)) {
@@ -282,12 +282,12 @@ export const AggregateCaviarninePositionsLive = Layer.effect(
                 baseToken: {
                   resourceAddress: pool.token_x,
                   amount: "0",
-                  isXrdOrDerivative: isXTokenXrdDerivative,
+                  isNativeAsset: isXTokenNativeAsset,
                 },
                 quoteToken: {
                   resourceAddress: pool.token_y,
                   amount: "0",
-                  isXrdOrDerivative: isYTokenXrdDerivative,
+                  isNativeAsset: isYTokenNativeAsset,
                 },
               },
             });
@@ -306,12 +306,12 @@ export const AggregateCaviarninePositionsLive = Layer.effect(
                 baseToken: {
                   resourceAddress: pool.token_x,
                   amount: "0",
-                  isXrdOrDerivative: isXTokenXrdDerivative,
+                  isNativeAsset: isXTokenNativeAsset,
                 },
                 quoteToken: {
                   resourceAddress: pool.token_y,
                   amount: "0",
-                  isXrdOrDerivative: isYTokenXrdDerivative,
+                  isNativeAsset: isYTokenNativeAsset,
                 },
               },
             });
@@ -330,12 +330,12 @@ export const AggregateCaviarninePositionsLive = Layer.effect(
               baseToken: {
                 resourceAddress: CaviarNineConstants.LSULP.resourceAddress,
                 amount: "0",
-                isXrdOrDerivative: true,
+                isNativeAsset: true,
               },
               quoteToken: {
                 resourceAddress: Assets.Fungible.XRD,
                 amount: "0",
-                isXrdOrDerivative: true,
+                isNativeAsset: true,
               },
             },
           });

--- a/packages/api/src/incentives/account-balance/aggregateCaviarninePositions.ts
+++ b/packages/api/src/incentives/account-balance/aggregateCaviarninePositions.ts
@@ -12,8 +12,11 @@ import type { AccountBalanceData, ActivityId, Token } from "db/incentives";
 import {
   AddressValidationService,
   type UnknownTokenError,
+  CONSTANT_PRODUCT_MULTIPLIER,
 } from "../../common/address-validation/addressValidation";
 import { getPair } from "../../common/helpers/getPair";
+import type { ShapeLiquidityAsset } from "../../common/dapps/caviarnine/getShapeLiquidityAssets";
+import type { CaviarnineSimplePoolLiquidityAsset } from "../../common/dapps/caviarnine/getCaviarnineResourcePoolPositions";
 
 export type AggregateCaviarninePositionsInput = {
   accountBalance: AccountBalanceFromSnapshot;
@@ -44,8 +47,24 @@ export const AggregateCaviarninePositionsLive = Layer.effect(
         const results: AccountBalanceData[] = [];
         const processedPools = new Set<string>();
 
-        // Process each pool in the CaviarNine positions
-        for (const [_poolKey, poolAssets] of Object.entries(
+        // Aggregate pools by token pair
+        const poolsByTokenPair = new Map<
+          string,
+          {
+            pools: {
+              poolKey: string;
+              poolAssets: (
+                | ShapeLiquidityAsset
+                | CaviarnineSimplePoolLiquidityAsset
+              )[];
+            }[];
+            xTokenInfo: { name: string; isNativeAsset: boolean };
+            yTokenInfo: { name: string; isNativeAsset: boolean };
+          }
+        >();
+
+        // First pass: group pools by token pair
+        for (const [poolKey, poolAssets] of Object.entries(
           input.accountBalance.caviarninePositions
         )) {
           const firstAsset = poolAssets[0];
@@ -66,62 +85,150 @@ export const AggregateCaviarninePositionsLive = Layer.effect(
               yToken.resourceAddress
             );
 
+          const tokenPairKey = getPair(
+            xTokenInfo.name as Token,
+            yTokenInfo.name as Token
+          );
+
+          if (!poolsByTokenPair.has(tokenPairKey)) {
+            poolsByTokenPair.set(tokenPairKey, {
+              pools: [],
+              xTokenInfo,
+              yTokenInfo,
+            });
+          }
+
+          poolsByTokenPair
+            .get(tokenPairKey)!
+            .pools.push({ poolKey, poolAssets });
+        }
+
+        // Second pass: process each token pair
+        for (const [
+          _tokenPairKey,
+          { pools, xTokenInfo, yTokenInfo },
+        ] of poolsByTokenPair) {
           const isXTokenNativeAsset = xTokenInfo.isNativeAsset;
           const isYTokenNativeAsset = yTokenInfo.isNativeAsset;
           const xTokenName = xTokenInfo.name;
           const yTokenName = yTokenInfo.name;
 
-          const totals = poolAssets.reduce(
-            (acc, item) => {
-              acc.totalXToken = acc.totalXToken.plus(
-                item.xToken.withinPriceBounds
-              );
-              acc.totalXTokenOutsidePriceBounds =
-                acc.totalXTokenOutsidePriceBounds.plus(
-                  item.xToken.outsidePriceBounds
+          // Aggregate totals across all pools for this token pair
+          let totalXToken = new BigNumber(0);
+          let totalYToken = new BigNumber(0);
+          let totalXTokenOutsidePriceBounds = new BigNumber(0);
+          let totalYTokenOutsidePriceBounds = new BigNumber(0);
+
+          const poolShares: Record<string, number> = {};
+          let totalUsdValue = new BigNumber(0);
+
+          // Pre-calculate all pool data in single pass to avoid redundant calculations
+          const poolData = [];
+          for (const { poolKey, poolAssets } of pools) {
+            const poolTotals = poolAssets.reduce(
+              (acc, item) => {
+                acc.totalXToken = acc.totalXToken.plus(
+                  item.xToken.withinPriceBounds
                 );
-              acc.totalYToken = acc.totalYToken.plus(
-                item.yToken.withinPriceBounds
-              );
-              acc.totalYTokenOutsidePriceBounds =
-                acc.totalYTokenOutsidePriceBounds.plus(
-                  item.yToken.outsidePriceBounds
+                acc.totalXTokenOutsidePriceBounds =
+                  acc.totalXTokenOutsidePriceBounds.plus(
+                    item.xToken.outsidePriceBounds
+                  );
+                acc.totalYToken = acc.totalYToken.plus(
+                  item.yToken.withinPriceBounds
                 );
-              return acc;
-            },
-            {
-              totalXToken: new BigNumber(0),
-              totalYToken: new BigNumber(0),
-              totalXTokenOutsidePriceBounds: new BigNumber(0),
-              totalYTokenOutsidePriceBounds: new BigNumber(0),
+                acc.totalYTokenOutsidePriceBounds =
+                  acc.totalYTokenOutsidePriceBounds.plus(
+                    item.yToken.outsidePriceBounds
+                  );
+                return acc;
+              },
+              {
+                totalXToken: new BigNumber(0),
+                totalYToken: new BigNumber(0),
+                totalXTokenOutsidePriceBounds: new BigNumber(0),
+                totalYTokenOutsidePriceBounds: new BigNumber(0),
+              }
+            );
+
+            // Calculate USD values for this pool
+            const xTokenUsdValue = poolTotals.totalXToken.gt(0)
+              ? yield* getUsdValueService({
+                  amount: poolTotals.totalXToken,
+                  resourceAddress: poolAssets[0]!.xToken.resourceAddress,
+                  timestamp: input.timestamp,
+                })
+              : new BigNumber(0);
+
+            const yTokenUsdValue = poolTotals.totalYToken.gt(0)
+              ? yield* getUsdValueService({
+                  amount: poolTotals.totalYToken,
+                  resourceAddress: poolAssets[0]!.yToken.resourceAddress,
+                  timestamp: input.timestamp,
+                })
+              : new BigNumber(0);
+
+            // Check if this specific pool is constant product and apply multiplier
+            const isPoolConstantProduct =
+              addressValidationService.isConstantProductPool(poolKey);
+            const poolMultiplier = isPoolConstantProduct
+              ? CONSTANT_PRODUCT_MULTIPLIER
+              : 1;
+
+            const poolUsdValue = xTokenUsdValue
+              .plus(yTokenUsdValue)
+              .multipliedBy(poolMultiplier);
+            totalUsdValue = totalUsdValue.plus(poolUsdValue);
+
+            // Store all calculated values for later use
+            poolData.push({
+              poolKey,
+              poolAssets,
+              poolTotals,
+              xTokenUsdValue,
+              yTokenUsdValue,
+              poolMultiplier,
+              poolUsdValue,
+            });
+
+            // Add to overall totals
+            totalXToken = totalXToken.plus(poolTotals.totalXToken);
+            totalYToken = totalYToken.plus(poolTotals.totalYToken);
+            totalXTokenOutsidePriceBounds = totalXTokenOutsidePriceBounds.plus(
+              poolTotals.totalXTokenOutsidePriceBounds
+            );
+            totalYTokenOutsidePriceBounds = totalYTokenOutsidePriceBounds.plus(
+              poolTotals.totalYTokenOutsidePriceBounds
+            );
+          }
+
+          // Calculate pool shares using pre-calculated values
+          for (const { poolKey, poolUsdValue } of poolData) {
+            if (totalUsdValue.gt(0)) {
+              poolShares[poolKey] = poolUsdValue
+                .dividedBy(totalUsdValue)
+                .toNumber();
             }
-          );
+          }
 
-          // Calculate USD values for both tokens upfront (only if amounts > 0)
-          const xTokenUsdValue = totals.totalXToken.gt(0)
+          // Calculate individual token USD values for proper split
+          const xTokenUsdValue = totalXToken.gt(0)
             ? yield* getUsdValueService({
-                amount: totals.totalXToken,
-                resourceAddress: xToken.resourceAddress,
+                amount: totalXToken,
+                resourceAddress:
+                  pools[0]!.poolAssets[0]!.xToken.resourceAddress,
                 timestamp: input.timestamp,
               })
             : new BigNumber(0);
 
-          const yTokenUsdValue = totals.totalYToken.gt(0)
+          const yTokenUsdValue = totalYToken.gt(0)
             ? yield* getUsdValueService({
-                amount: totals.totalYToken,
-                resourceAddress: yToken.resourceAddress,
+                amount: totalYToken,
+                resourceAddress:
+                  pools[0]!.poolAssets[0]!.yToken.resourceAddress,
                 timestamp: input.timestamp,
               })
             : new BigNumber(0);
-
-          // Split values based on XRD derivative status
-          const totalWrappedAssetUsdValue = new BigNumber(0)
-            .plus(isXTokenNativeAsset ? 0 : xTokenUsdValue)
-            .plus(isYTokenNativeAsset ? 0 : yTokenUsdValue);
-
-          const totalNativeAssetUsdValue = new BigNumber(0)
-            .plus(isXTokenNativeAsset ? xTokenUsdValue : 0)
-            .plus(isYTokenNativeAsset ? yTokenUsdValue : 0);
 
           // Generate activity IDs based on token pair
           const nonNativeActivityId = `c9_lp_${getPair(
@@ -137,50 +244,69 @@ export const AggregateCaviarninePositionsLive = Layer.effect(
           processedPools.add(nonNativeActivityId);
           processedPools.add(nativeActivityId);
 
-          // Add non-native LP activity (non-XRD derivative tokens only)
-          results.push({
-            activityId: nonNativeActivityId,
-            usdValue: totalWrappedAssetUsdValue.toString(),
-            metadata: {
+          // Create separate metadata for each pool using pre-calculated data
+          const poolMetadata: Record<string, any> = {};
+          for (const { poolKey, poolAssets, poolTotals } of poolData) {
+            poolMetadata[poolKey] = {
+              componentAddress: poolKey,
               tokenPair: getPair(xTokenName as Token, yTokenName as Token),
               baseToken: {
-                resourceAddress: xToken.resourceAddress,
-                amount: totals.totalXToken.toString(),
+                resourceAddress: poolAssets[0]!.xToken.resourceAddress,
+                amount: poolTotals.totalXToken.toString(),
                 outsidePriceBounds:
-                  totals.totalXTokenOutsidePriceBounds.toString(),
+                  poolTotals.totalXTokenOutsidePriceBounds.toString(),
                 isNativeAsset: isXTokenNativeAsset,
               },
               quoteToken: {
-                resourceAddress: yToken.resourceAddress,
-                amount: totals.totalYToken.toString(),
+                resourceAddress: poolAssets[0]!.yToken.resourceAddress,
+                amount: poolTotals.totalYToken.toString(),
                 outsidePriceBounds:
-                  totals.totalYTokenOutsidePriceBounds.toString(),
+                  poolTotals.totalYTokenOutsidePriceBounds.toString(),
                 isNativeAsset: isYTokenNativeAsset,
               },
-            },
+            };
+          }
+
+          // Calculate wrapped and native asset portions from the totalUsdValue
+          const wrappedAssetPortion = new BigNumber(0)
+            .plus(isXTokenNativeAsset ? 0 : xTokenUsdValue)
+            .plus(isYTokenNativeAsset ? 0 : yTokenUsdValue);
+
+          const nativeAssetPortion = new BigNumber(0)
+            .plus(isXTokenNativeAsset ? xTokenUsdValue : 0)
+            .plus(isYTokenNativeAsset ? yTokenUsdValue : 0);
+
+          const totalPortion = wrappedAssetPortion.plus(nativeAssetPortion);
+
+          // Calculate final USD values using the already-multiplied totalUsdValue
+          const finalWrappedAssetUsdValue = totalPortion.gt(0)
+            ? totalUsdValue
+                .multipliedBy(wrappedAssetPortion)
+                .dividedBy(totalPortion)
+            : new BigNumber(0);
+
+          const finalNativeAssetUsdValue = totalPortion.gt(0)
+            ? totalUsdValue
+                .multipliedBy(nativeAssetPortion)
+                .dividedBy(totalPortion)
+            : new BigNumber(0);
+
+          // Add non-native LP activity (non-XRD derivative tokens only)
+          results.push({
+            activityId: nonNativeActivityId,
+            usdValue: finalWrappedAssetUsdValue.toString(),
+            poolShare:
+              Object.keys(poolShares).length > 1 ? poolShares : undefined,
+            metadata: poolMetadata,
           });
 
           // Add native LP activity (XRD derivatives only)
           results.push({
             activityId: nativeActivityId,
-            usdValue: totalNativeAssetUsdValue.toString(),
-            metadata: {
-              tokenPair: getPair(xTokenName as Token, yTokenName as Token),
-              baseToken: {
-                resourceAddress: xToken.resourceAddress,
-                amount: totals.totalXToken.toString(),
-                outsidePriceBounds:
-                  totals.totalXTokenOutsidePriceBounds.toString(),
-                isNativeAsset: isXTokenNativeAsset,
-              },
-              quoteToken: {
-                resourceAddress: yToken.resourceAddress,
-                amount: totals.totalYToken.toString(),
-                outsidePriceBounds:
-                  totals.totalYTokenOutsidePriceBounds.toString(),
-                isNativeAsset: isYTokenNativeAsset,
-              },
-            },
+            usdValue: finalNativeAssetUsdValue.toString(),
+            poolShare:
+              Object.keys(poolShares).length > 1 ? poolShares : undefined,
+            metadata: poolMetadata,
           });
         }
 

--- a/packages/api/src/incentives/account-balance/aggregateOciswapPositions.ts
+++ b/packages/api/src/incentives/account-balance/aggregateOciswapPositions.ts
@@ -60,16 +60,16 @@ export const AggregateOciswapPositionsLive = Layer.effect(
 
           // Get token info including XRD derivative status
           const xTokenInfo =
-            yield* addressValidationService.getTokenNameAndXrdStatus(
+            yield* addressValidationService.getTokenNameAndNativeAssetStatus(
               xToken.resourceAddress
             );
           const yTokenInfo =
-            yield* addressValidationService.getTokenNameAndXrdStatus(
+            yield* addressValidationService.getTokenNameAndNativeAssetStatus(
               yToken.resourceAddress
             );
 
-          const isXTokenXrdDerivative = xTokenInfo.isXrdDerivative;
-          const isYTokenXrdDerivative = yTokenInfo.isXrdDerivative;
+          const isXTokenNativeAsset = xTokenInfo.isNativeAsset;
+          const isYTokenNativeAsset = yTokenInfo.isNativeAsset;
           const xTokenName = xTokenInfo.name;
           const yTokenName = yTokenInfo.name;
 
@@ -123,12 +123,12 @@ export const AggregateOciswapPositionsLive = Layer.effect(
 
           // Split values based on XRD derivative status
           const totalNonXrdUsdValue = new BigNumber(0)
-            .plus(isXTokenXrdDerivative ? 0 : xTokenUsdValue)
-            .plus(isYTokenXrdDerivative ? 0 : yTokenUsdValue);
+            .plus(isXTokenNativeAsset ? 0 : xTokenUsdValue)
+            .plus(isYTokenNativeAsset ? 0 : yTokenUsdValue);
 
-          const totalXrdDerivativeUsdValue = new BigNumber(0)
-            .plus(isXTokenXrdDerivative ? xTokenUsdValue : 0)
-            .plus(isYTokenXrdDerivative ? yTokenUsdValue : 0);
+          const totalNativeAssetUsdValue = new BigNumber(0)
+            .plus(isXTokenNativeAsset ? xTokenUsdValue : 0)
+            .plus(isYTokenNativeAsset ? yTokenUsdValue : 0);
 
           // Generate activity IDs based on token pair
           const nonNativeActivityId =
@@ -155,14 +155,14 @@ export const AggregateOciswapPositionsLive = Layer.effect(
                       amount: totals.totalXToken.toString(),
                       outsidePriceBounds:
                         totals.totalXTokenOutsidePriceBounds.toString(),
-                      isXrdOrDerivative: isXTokenXrdDerivative,
+                      isNativeAsset: isXTokenNativeAsset,
                     },
                     quoteToken: {
                       resourceAddress: yToken.resourceAddress,
                       amount: totals.totalYToken.toString(),
                       outsidePriceBounds:
                         totals.totalYTokenOutsidePriceBounds.toString(),
-                      isXrdOrDerivative: isYTokenXrdDerivative,
+                      isNativeAsset: isYTokenNativeAsset,
                     },
                   },
                 }
@@ -177,7 +177,7 @@ export const AggregateOciswapPositionsLive = Layer.effect(
             STORE_METADATA
               ? {
                   activityId: nativeActivityId,
-                  usdValue: totalXrdDerivativeUsdValue.toString(),
+                  usdValue: totalNativeAssetUsdValue.toString(),
                   metadata: {
                     tokenPair: getPair(
                       xTokenName as Token,
@@ -188,20 +188,20 @@ export const AggregateOciswapPositionsLive = Layer.effect(
                       amount: totals.totalXToken.toString(),
                       outsidePriceBounds:
                         totals.totalXTokenOutsidePriceBounds.toString(),
-                      isXrdOrDerivative: isXTokenXrdDerivative,
+                      isNativeAsset: isXTokenNativeAsset,
                     },
                     quoteToken: {
                       resourceAddress: yToken.resourceAddress,
                       amount: totals.totalYToken.toString(),
                       outsidePriceBounds:
                         totals.totalYTokenOutsidePriceBounds.toString(),
-                      isXrdOrDerivative: isYTokenXrdDerivative,
+                      isNativeAsset: isYTokenNativeAsset,
                     },
                   },
                 }
               : {
                   activityId: nativeActivityId,
-                  usdValue: totalXrdDerivativeUsdValue.toString(),
+                  usdValue: totalNativeAssetUsdValue.toString(),
                 }
           );
         }
@@ -216,11 +216,11 @@ export const AggregateOciswapPositionsLive = Layer.effect(
 
         for (const pool of allPools) {
           const xTokenInfo =
-            yield* addressValidationService.getTokenNameAndXrdStatus(
+            yield* addressValidationService.getTokenNameAndNativeAssetStatus(
               pool.token_x
             );
           const yTokenInfo =
-            yield* addressValidationService.getTokenNameAndXrdStatus(
+            yield* addressValidationService.getTokenNameAndNativeAssetStatus(
               pool.token_y
             );
           const nonNativeActivityId =
@@ -229,8 +229,8 @@ export const AggregateOciswapPositionsLive = Layer.effect(
             `oci_nativeLp_${getPair(xTokenInfo.name as Token, yTokenInfo.name as Token)}` as ActivityId;
 
           // Get XRD derivative status from the centralized function
-          const isXTokenXrdDerivative = xTokenInfo.isXrdDerivative;
-          const isYTokenXrdDerivative = yTokenInfo.isXrdDerivative;
+          const isXTokenNativeAsset = xTokenInfo.isNativeAsset;
+          const isYTokenNativeAsset = yTokenInfo.isNativeAsset;
 
           // Add zero entry for non-native LP if not processed
           if (!processedPools.has(nonNativeActivityId)) {
@@ -248,13 +248,13 @@ export const AggregateOciswapPositionsLive = Layer.effect(
                         resourceAddress: pool.token_x,
                         amount: "0",
                         outsidePriceBounds: "0",
-                        isXrdOrDerivative: isXTokenXrdDerivative,
+                        isNativeAsset: isXTokenNativeAsset,
                       },
                       quoteToken: {
                         resourceAddress: pool.token_y,
                         amount: "0",
                         outsidePriceBounds: "0",
-                        isXrdOrDerivative: isYTokenXrdDerivative,
+                        isNativeAsset: isYTokenNativeAsset,
                       },
                     },
                   }
@@ -281,13 +281,13 @@ export const AggregateOciswapPositionsLive = Layer.effect(
                         resourceAddress: pool.token_x,
                         amount: "0",
                         outsidePriceBounds: "0",
-                        isXrdOrDerivative: isXTokenXrdDerivative,
+                        isNativeAsset: isXTokenNativeAsset,
                       },
                       quoteToken: {
                         resourceAddress: pool.token_y,
                         amount: "0",
                         outsidePriceBounds: "0",
-                        isXrdOrDerivative: isYTokenXrdDerivative,
+                        isNativeAsset: isYTokenNativeAsset,
                       },
                     },
                   }

--- a/packages/api/src/incentives/account-balance/getAccountBalancesAtStateVersion.ts
+++ b/packages/api/src/incentives/account-balance/getAccountBalancesAtStateVersion.ts
@@ -58,10 +58,12 @@ import {
   GetShapeLiquidityAssetsService,
   type ShapeLiquidityAsset,
 } from "../../common/dapps/caviarnine/getShapeLiquidityAssets";
+import { type CaviarnineSimplePoolLiquidityAsset } from "../../common/dapps/caviarnine/getCaviarnineResourcePoolPositions";
 import {
   GetOciswapLiquidityAssetsService,
   type OciswapLiquidityAsset,
 } from "../../common/dapps/ociswap/getOciswapLiquidityAssets";
+import { type OciswapResourcePoolLiquidityAsset } from "../../common/dapps/ociswap/getOciswapResourcePoolPositions";
 import { OciswapConstants } from "../../common/dapps/ociswap/constants";
 import type { FailedToParseComponentStateError } from "../../common/dapps/caviarnine/getQuantaSwapBinMap";
 import type { FailedToParseLiquidityClaimsError } from "../../common/dapps/caviarnine/getShapeLiquidityClaims";
@@ -135,11 +137,11 @@ type WeftFinancePosition = GetWeftFinancePositionsOutput;
 type RootFinancePosition = CollaterizedDebtPosition;
 
 type CaviarNinePosition = {
-  [key: string]: ShapeLiquidityAsset[];
+  [key: string]: ShapeLiquidityAsset[] | CaviarnineSimplePoolLiquidityAsset[];
 };
 
 type OciswapPosition = {
-  [key: string]: OciswapLiquidityAsset[];
+  [key: string]: OciswapLiquidityAsset[] | OciswapResourcePoolLiquidityAsset[];
 };
 
 type DefiPlazaPosition = GetDefiPlazaPositionsOutput[number];
@@ -438,7 +440,7 @@ export const GetAccountBalancesAtStateVersionLive = Layer.effect(
               })
               .pipe(Effect.withSpan("getSurgeLiquidityPositionsService")),
             getOciswapResourcePoolPositionsService
-              .getOciswapResourcePoolPositions({
+              .run({
                 accountAddresses: input.addresses,
                 at_ledger_state: atLedgerState,
                 fungibleBalance: fungibleBalanceResults,
@@ -446,9 +448,10 @@ export const GetAccountBalancesAtStateVersionLive = Layer.effect(
               })
               .pipe(Effect.withSpan("getOciswapResourcePoolPositionsService")),
             getCaviarnineResourcePoolPositionsService
-              .getCaviarnineResourcePoolPositions({
+              .run({
                 addresses: input.addresses,
                 at_ledger_state: atLedgerState,
+                fungibleBalance: fungibleBalanceResults,
               })
               .pipe(
                 Effect.withSpan("getCaviarnineResourcePoolPositionsService")
@@ -662,7 +665,7 @@ export const GetAccountBalancesAtStateVersionLive = Layer.effect(
                   (r) => r.address === address
                 );
                 if (addressResult && addressResult.items.length > 0) {
-                  const poolKey = pool.name.replace("/", "_");
+                  const poolKey = pool.componentAddress;
                   caviarninePositions[poolKey] = addressResult.items;
                 }
               }

--- a/packages/api/src/incentives/dependencyLayer.ts
+++ b/packages/api/src/incentives/dependencyLayer.ts
@@ -30,6 +30,7 @@ import { GetShapeLiquidityClaimsLive } from "../common/dapps/caviarnine/getShape
 import { GetShapeLiquidityAssetsLive } from "../common/dapps/caviarnine/getShapeLiquidityAssets";
 import { GetOciswapLiquidityAssetsLive } from "../common/dapps/ociswap/getOciswapLiquidityAssets";
 import { GetOciswapLiquidityClaimsLive } from "../common/dapps/ociswap/getOciswapLiquidityClaims";
+import { GetOciswapResourcePoolPositionsLive } from "../common/dapps/ociswap/getOciswapResourcePoolPositions";
 import { GetDefiPlazaPositionsLive } from "../common/dapps/defiplaza/getDefiPlazaPositions";
 import { GetHyperstakePositionsLive } from "../common/dapps/caviarnine/getHyperstakePositions";
 import { GetResourcePoolUnitsLive } from "../common/resource-pool/getResourcePoolUnits";
@@ -321,6 +322,11 @@ const getHyperstakePositionsLive = GetHyperstakePositionsLive.pipe(
   Layer.provide(getResourcePoolUnitsLive)
 );
 
+const getOciswapResourcePoolPositionsLive = GetOciswapResourcePoolPositionsLive.pipe(
+  Layer.provide(getFungibleBalanceLive),
+  Layer.provide(getResourcePoolUnitsLive)
+);
+
 const aggregateDefiPlazaPositionsLive = AggregateDefiPlazaPositionsLive.pipe(
   Layer.provide(getUsdValueLive),
   Layer.provide(addressValidationServiceLive)
@@ -378,6 +384,7 @@ const dappsLive = Layer.mergeAll(
   getQuantaSwapBinMapLive,
   getOciswapLiquidityAssetsLive,
   getOciswapLiquidityClaimsLive,
+  getOciswapResourcePoolPositionsLive,
   getSurgeLiquidityPositionsLive
 );
 

--- a/packages/api/src/incentives/dependencyLayer.ts
+++ b/packages/api/src/incentives/dependencyLayer.ts
@@ -31,6 +31,7 @@ import { GetShapeLiquidityAssetsLive } from "../common/dapps/caviarnine/getShape
 import { GetOciswapLiquidityAssetsLive } from "../common/dapps/ociswap/getOciswapLiquidityAssets";
 import { GetOciswapLiquidityClaimsLive } from "../common/dapps/ociswap/getOciswapLiquidityClaims";
 import { GetOciswapResourcePoolPositionsLive } from "../common/dapps/ociswap/getOciswapResourcePoolPositions";
+import { GetCaviarnineResourcePoolPositionsLive } from "../common/dapps/caviarnine/getCaviarnineResourcePoolPositions";
 import { GetDefiPlazaPositionsLive } from "../common/dapps/defiplaza/getDefiPlazaPositions";
 import { GetHyperstakePositionsLive } from "../common/dapps/caviarnine/getHyperstakePositions";
 import { GetResourcePoolUnitsLive } from "../common/resource-pool/getResourcePoolUnits";
@@ -322,10 +323,17 @@ const getHyperstakePositionsLive = GetHyperstakePositionsLive.pipe(
   Layer.provide(getResourcePoolUnitsLive)
 );
 
-const getOciswapResourcePoolPositionsLive = GetOciswapResourcePoolPositionsLive.pipe(
-  Layer.provide(getFungibleBalanceLive),
-  Layer.provide(getResourcePoolUnitsLive)
-);
+const getOciswapResourcePoolPositionsLive =
+  GetOciswapResourcePoolPositionsLive.pipe(
+    Layer.provide(getFungibleBalanceLive),
+    Layer.provide(getResourcePoolUnitsLive)
+  );
+
+const getCaviarnineResourcePoolPositionsLive =
+  GetCaviarnineResourcePoolPositionsLive.pipe(
+    Layer.provide(getFungibleBalanceLive),
+    Layer.provide(getResourcePoolUnitsLive)
+  );
 
 const aggregateDefiPlazaPositionsLive = AggregateDefiPlazaPositionsLive.pipe(
   Layer.provide(getUsdValueLive),
@@ -385,6 +393,7 @@ const dappsLive = Layer.mergeAll(
   getOciswapLiquidityAssetsLive,
   getOciswapLiquidityClaimsLive,
   getOciswapResourcePoolPositionsLive,
+  getCaviarnineResourcePoolPositionsLive,
   getSurgeLiquidityPositionsLive
 );
 

--- a/packages/api/src/incentives/events/event-matchers/ociswapEventMatcher.ts
+++ b/packages/api/src/incentives/events/event-matchers/ociswapEventMatcher.ts
@@ -74,6 +74,8 @@ export const ociswapEventMatcherFn = (input: TransformedEvent) =>
       case "InstantiateEvent":
       case "AddLiquidityEvent":
       case "RemoveLiquidityEvent":
+      case "DepositEvent":
+      case "WithdrawEvent":
         return yield* Effect.succeed(null);
     }
 

--- a/packages/api/src/incentives/trading-volume/filterTradingEvents.ts
+++ b/packages/api/src/incentives/trading-volume/filterTradingEvents.ts
@@ -13,7 +13,6 @@ import type { ActivityId } from "db/incentives";
 import { defiPlazaComponentSet } from "../../common/dapps/defiplaza/constants";
 import type { DefiPlazaSwapEvent } from "../events/event-matchers/defiPlazaEventMatcher";
 import type { HLPEmittableEvents } from "../events/event-matchers/hlpEventMatcher";
-import { ociswapComponentSet } from "../../common/dapps/ociswap/constants";
 import type { OciswapSwapEvent } from "../events/event-matchers/ociswapEventMatcher";
 import { AddressValidationService } from "../../common/address-validation/addressValidation";
 
@@ -188,13 +187,12 @@ export const FilterTradingEventsLive = Layer.effect(
             event.eventData.type === "SwapEvent"
           ) {
             const swapEvent = event as CapturedEvent<OciswapSwapEvent>;
-            const pool = ociswapComponentSet.get(swapEvent.globalEmitter);
             const activityId =
               addressValidationService.getTradingActivityIdForPool(
                 swapEvent.globalEmitter
               );
 
-            if (pool && activityId) {
+            if (activityId) {
               const swapData = swapEvent.eventData.data;
               const inputAmount = new BigNumber(swapData.input_amount);
               const inputToken = swapData.input_address;

--- a/packages/db/src/incentives/seed/data/activitiesData.ts
+++ b/packages/db/src/incentives/seed/data/activitiesData.ts
@@ -76,6 +76,68 @@ export const activitiesData = [
     category: ActivityCategoryKey.provideNativeLiquidityToDex,
   },
 
+  // New nativeLp activities for stables
+  {
+    id: `c9_nativeLp_${getPair("xrd", "xusdc")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `defiPlaza_nativeLp_${getPair("xrd", "xusdc")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `oci_nativeLp_${getPair("xrd", "xusdc")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `c9_nativeLp_${getPair("xrd", "xusdt")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `defiPlaza_nativeLp_${getPair("xrd", "xusdt")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `oci_nativeLp_${getPair("xrd", "xusdt")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+
+  // New nativeLp activities for blue chips
+  {
+    id: `c9_nativeLp_${getPair("xrd", "xeth")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `oci_nativeLp_${getPair("xrd", "xeth")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `c9_nativeLp_${getPair("xwbtc", "xrd")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `oci_nativeLp_${getPair("xwbtc", "xrd")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `defiPlaza_nativeLp_${getPair("xrd", "xeth")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `defiPlaza_nativeLp_${getPair("xrd", "xwbtc")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+
+  // New nativeLp activities for native assets
+  {
+    id: `c9_nativeLp_${getPair("lsulp", "xrd")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: "c9_nativeLp_hyperstake",
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+
   // Lending activities
   {
     id: "root_lend_xusdc",
@@ -201,6 +263,26 @@ export const activitiesData = [
   },
   {
     id: "c9_hold_hyperstake",
+    category: ActivityCategoryKey.maintainXrdBalance,
+  },
+  {
+    id: `oci_hold_${getPair("early", "xrd")}`,
+    category: ActivityCategoryKey.maintainXrdBalance,
+  },
+  {
+    id: `oci_hold_${getPair("ilis", "xrd")}`,
+    category: ActivityCategoryKey.maintainXrdBalance,
+  },
+  {
+    id: `oci_hold_${getPair("oci", "xrd")}`,
+    category: ActivityCategoryKey.maintainXrdBalance,
+  },
+  {
+    id: `defiPlaza_hold_${getPair("dfp2", "astrl")}`,
+    category: ActivityCategoryKey.maintainXrdBalance,
+  },
+  {
+    id: `defiPlaza_hold_${getPair("dfp2", "xrd")}`,
     category: ActivityCategoryKey.maintainXrdBalance,
   },
 

--- a/packages/db/src/incentives/seed/data/activitiesData.ts
+++ b/packages/db/src/incentives/seed/data/activitiesData.ts
@@ -75,6 +75,34 @@ export const activitiesData = [
     id: "c9_lp_hyperstake",
     category: ActivityCategoryKey.provideNativeLiquidityToDex,
   },
+  {
+    id: `c9_lp_${getPair("reddicks", "lsulp")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `c9_lp_${getPair("floop", "xrd")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `oci_lp_${getPair("oci", "xrd")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `oci_lp_${getPair("ilis", "xrd")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `oci_lp_${getPair("early", "xrd")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `defiPlaza_lp_${getPair("astrl", "dfp2")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `defiPlaza_lp_${getPair("xrd", "dfp2")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
 
   // New nativeLp activities for stables
   {
@@ -135,6 +163,34 @@ export const activitiesData = [
   },
   {
     id: "c9_nativeLp_hyperstake",
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `c9_nativeLp_${getPair("reddicks", "lsulp")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `c9_nativeLp_${getPair("floop", "xrd")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `oci_nativeLp_${getPair("oci", "xrd")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `oci_nativeLp_${getPair("ilis", "xrd")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `oci_nativeLp_${getPair("early", "xrd")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `defiPlaza_nativeLp_${getPair("astrl", "dfp2")}`,
+    category: ActivityCategoryKey.provideNativeLiquidityToDex,
+  },
+  {
+    id: `defiPlaza_nativeLp_${getPair("xrd", "dfp2")}`,
     category: ActivityCategoryKey.provideNativeLiquidityToDex,
   },
 
@@ -285,6 +341,14 @@ export const activitiesData = [
     id: `defiPlaza_hold_${getPair("dfp2", "xrd")}`,
     category: ActivityCategoryKey.maintainXrdBalance,
   },
+  {
+    id: `c9_hold_${getPair("floop", "xrd")}`,
+    category: ActivityCategoryKey.maintainXrdBalance,
+  },
+  {
+    id: `c9_hold_${getPair("reddicks", "lsulp")}`,
+    category: ActivityCategoryKey.maintainXrdBalance,
+  },
 
   // Season multiplier Hodl activities XRD activities through lending positions
   {
@@ -376,6 +440,34 @@ export const activitiesData = [
   },
   {
     id: `oci_trade_${getPair("xrd", "xwbtc")}`,
+    category: ActivityCategoryKey.tradingVolume,
+  },
+  {
+    id: `c9_trade_${getPair("reddicks", "lsulp")}`,
+    category: ActivityCategoryKey.tradingVolume,
+  },
+  {
+    id: `c9_trade_${getPair("floop", "xrd")}`,
+    category: ActivityCategoryKey.tradingVolume,
+  },
+  {
+    id: `oci_trade_${getPair("oci", "xrd")}`,
+    category: ActivityCategoryKey.tradingVolume,
+  },
+  {
+    id: `oci_trade_${getPair("ilis", "xrd")}`,
+    category: ActivityCategoryKey.tradingVolume,
+  },
+  {
+    id: `oci_trade_${getPair("early", "xrd")}`,
+    category: ActivityCategoryKey.tradingVolume,
+  },
+  {
+    id: `defiPlaza_trade_${getPair("astrl", "dfp2")}`,
+    category: ActivityCategoryKey.tradingVolume,
+  },
+  {
+    id: `defiPlaza_trade_${getPair("xrd", "dfp2")}`,
     category: ActivityCategoryKey.tradingVolume,
   },
 ];

--- a/packages/db/src/incentives/types.ts
+++ b/packages/db/src/incentives/types.ts
@@ -41,15 +41,24 @@ const testTokens = [
   "fomo",
 ];
 
+// TODO: this seems double, together with address-validation and its token map.
+// we might want to clean that up a bit
 export const TOKENS = {
   xrd: "xrd",
+  lsulp: "lsulp",
+  stakedXrd: "stakedXrd",
+  unstakedXrd: "unstakedXrd",
+
+  astrl: "astrl",
+  dfp2: "dfp2",
+  ilis: "ilis",
+  oci: "oci",
+  early: "early",
+
   xeth: "xeth",
   xusdc: "xusdc",
   xusdt: "xusdt",
   xwbtc: "xwbtc",
-  lsulp: "lsulp",
-  stakedXrd: "stakedXrd",
-  unstakedXrd: "unstakedXrd",
 } as const;
 export type Token = keyof typeof TOKENS;
 

--- a/packages/db/src/incentives/types.ts
+++ b/packages/db/src/incentives/types.ts
@@ -54,6 +54,8 @@ export const TOKENS = {
   ilis: "ilis",
   oci: "oci",
   early: "early",
+  floop: "floop",
+  reddicks: "reddicks",
 
   xeth: "xeth",
   xusdc: "xusdc",

--- a/packages/db/src/incentives/types.ts
+++ b/packages/db/src/incentives/types.ts
@@ -116,6 +116,7 @@ export const AccountBalanceData = z.object({
   activityId: z.string(),
   usdValue: z.string(),
   metadata: z.record(z.string(), z.unknown()).optional(),
+  poolShare: z.record(z.string(), z.number()).optional(),
 });
 
 export type AccountBalanceData = Omit<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1071,6 +1071,55 @@ importers:
         specifier: 'catalog:'
         version: 3.1.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.8.0)
 
+  tools/calculate-points:
+    dependencies:
+      '@testcontainers/postgresql':
+        specifier: 'catalog:'
+        version: 11.2.1
+      '@types/fs-extra':
+        specifier: ^11.0.4
+        version: 11.0.4
+      api:
+        specifier: workspace:*
+        version: link:../../packages/api
+      bignumber.js:
+        specifier: 'catalog:'
+        version: 9.3.0
+      commander:
+        specifier: 'catalog:'
+        version: 12.1.0
+      db:
+        specifier: workspace:*
+        version: link:../../packages/db
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 0.33.0(@opentelemetry/api@1.9.0)(@types/react@19.1.0)(postgres@3.4.5)(react@19.1.0)
+      effect:
+        specifier: 'catalog:'
+        version: 3.14.6
+      fs-extra:
+        specifier: ^11.3.0
+        version: 11.3.0
+      inquirer:
+        specifier: 'catalog:'
+        version: 8.2.6
+      postgres:
+        specifier: 'catalog:'
+        version: 3.4.5
+    devDependencies:
+      '@types/inquirer':
+        specifier: 'catalog:'
+        version: 9.0.8
+      tsup:
+        specifier: 'catalog:'
+        version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.8.0)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.19.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.1.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.8.0)
+
   tools/queue-helper:
     dependencies:
       db:
@@ -9255,14 +9304,14 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9957,7 +10006,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       module-details-from-path: 1.0.4
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -10098,7 +10147,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.1
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color
@@ -10510,7 +10559,7 @@ snapshots:
   vite-node@3.1.2(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0
+      debug: 4.4.1
       es-module-lexer: 1.6.0
       pathe: 2.0.3
       vite: 6.2.5(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.8.0)

--- a/tools/calculate-points/.gitignore
+++ b/tools/calculate-points/.gitignore
@@ -1,0 +1,16 @@
+# SQL dumps
+dumps/
+dump.sql
+
+# Output files
+output/
+
+# Built files
+dist/
+
+# Node modules
+node_modules/
+
+# Environment files
+.env
+.env.local

--- a/tools/calculate-points/package.json
+++ b/tools/calculate-points/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "calculate-points",
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "calc:sp": "tsx --watch src/calculateSeasonPoints.ts"
+  },
+  "devDependencies": {
+    "tsup": "catalog:",
+    "tsx": "catalog:",
+    "vitest": "catalog:",
+    "@types/inquirer": "catalog:"
+  },
+  "dependencies": {
+    "@testcontainers/postgresql": "catalog:",
+    "@types/fs-extra": "^11.0.4",
+    "api": "workspace:*",
+    "bignumber.js": "catalog:",
+    "commander": "catalog:",
+    "db": "workspace:*",
+    "drizzle-orm": "catalog:",
+    "effect": "catalog:",
+    "fs-extra": "^11.3.0",
+    "inquirer": "catalog:",
+    "postgres": "catalog:"
+  }
+}

--- a/tools/calculate-points/src/calculateSeasonPoints.ts
+++ b/tools/calculate-points/src/calculateSeasonPoints.ts
@@ -1,0 +1,188 @@
+import {
+  activities,
+  seasons,
+  userSeasonPoints,
+  weeks,
+  accounts,
+  accountActivityPoints,
+  db,
+} from "db/incentives";
+import path from "node:path";
+import { eq } from "drizzle-orm";
+import { Effect, Layer, Logger } from "effect";
+import {
+  ActivityCategoryWeekService,
+  AddSeasonPointsToUserService,
+  CalculateSeasonPointsService,
+  createDbClientLive,
+  GetSeasonPointMultiplierService,
+  SeasonService,
+  UpdateWeekStatusService,
+  UserActivityPointsService,
+  WeekService,
+} from "api/incentives";
+import fs from "node:fs";
+import { groupBy } from "effect/Array";
+import { GetUsersPaginatedLive } from "../../../packages/api/src/incentives/user/getUsersPaginated";
+
+const WEEK_ID = "30da196b-7602-4b06-a558-bbb5b5441186";
+
+const runnable = Effect.gen(function* () {
+  const outputDir = path.join(import.meta.dirname, "../output");
+
+  yield* Effect.log("Running season points calculation");
+
+  const dbLayer = createDbClientLive(db);
+
+  const seasonServiceLive = SeasonService.Default.pipe(Layer.provide(dbLayer));
+  const weekServiceLive = WeekService.Default.pipe(Layer.provide(dbLayer));
+  const activityCategoryWeekServiceLive =
+    ActivityCategoryWeekService.Default.pipe(Layer.provide(dbLayer));
+  const userActivityPointsServiceLive = UserActivityPointsService.Default.pipe(
+    Layer.provide(dbLayer)
+  );
+  const getSeasonPointMultiplierServiceLive =
+    GetSeasonPointMultiplierService.Default.pipe(Layer.provide(dbLayer));
+
+  const addSeasonPointsToUserServiceLive =
+    AddSeasonPointsToUserService.Default.pipe(Layer.provide(dbLayer));
+
+  const updateWeekStatusServiceLive = UpdateWeekStatusService.Default.pipe(
+    Layer.provide(dbLayer)
+  );
+
+  const getUsersPaginatedServiceLive = GetUsersPaginatedLive.pipe(
+    Layer.provide(dbLayer)
+  );
+
+  const calculateSeasonPointsServiceLive =
+    CalculateSeasonPointsService.Default.pipe(
+      Layer.provide(seasonServiceLive),
+      Layer.provide(weekServiceLive),
+      Layer.provide(activityCategoryWeekServiceLive),
+      Layer.provide(userActivityPointsServiceLive),
+      Layer.provide(getSeasonPointMultiplierServiceLive),
+      Layer.provide(addSeasonPointsToUserServiceLive),
+      Layer.provide(updateWeekStatusServiceLive),
+      Layer.provide(getUsersPaginatedServiceLive)
+    );
+
+  const service = yield* Effect.provide(
+    CalculateSeasonPointsService,
+    calculateSeasonPointsServiceLive
+  );
+
+  const seasonId = yield* Effect.tryPromise(() =>
+    db.query.seasons
+      .findFirst({
+        where: eq(seasons.status, "active"),
+      })
+      .then((result) => result?.id)
+  );
+
+  const week = yield* Effect.tryPromise(() =>
+    db.query.weeks.findFirst({
+      where: eq(weeks.id, WEEK_ID),
+    })
+  );
+
+  if (!week) {
+    return yield* Effect.fail("Week not found");
+  }
+
+  const activityCategoryWeeks = yield* Effect.tryPromise(() =>
+    db.query.activityCategoryWeeks.findMany()
+  );
+
+  if (!seasonId) {
+    return yield* Effect.fail("Season not found");
+  }
+
+  if (activityCategoryWeeks.length === 0) {
+    return yield* Effect.fail("Activity category weeks not found");
+  }
+
+  yield* service.run({
+    weekId: week.id,
+    force: true,
+    markAsProcessed: false,
+  });
+
+  yield* Effect.log("Season points calculation complete");
+
+  yield* Effect.log("Writing results to file");
+
+  const userSeasonPointsResults = yield* Effect.tryPromise(() =>
+    db
+      .select()
+      .from(userSeasonPoints)
+      .where(eq(userSeasonPoints.weekId, week.id))
+  );
+
+  const accountActivityPointsResults = yield* Effect.tryPromise(() =>
+    db
+      .select({
+        userId: accounts.userId,
+        weekId: accountActivityPoints.weekId,
+        activityId: accountActivityPoints.activityId,
+        activityPoints: accountActivityPoints.activityPoints,
+        accountAddress: accounts.address,
+        activityCategory: activities.category,
+      })
+      .from(accountActivityPoints)
+      .where(eq(accountActivityPoints.weekId, week.id))
+      .innerJoin(
+        accounts,
+        eq(accountActivityPoints.accountAddress, accounts.address)
+      )
+      .innerJoin(
+        activities,
+        eq(accountActivityPoints.activityId, activities.id)
+      )
+  );
+
+  const groupedByUserId = groupBy(
+    accountActivityPointsResults,
+    (item) => item.userId
+  );
+
+  const withActivityPoints = userSeasonPointsResults.map(
+    ({ userId, points }) => ({
+      userId,
+      seasonPoints: points,
+      activityPoints: groupedByUserId[userId]?.map(
+        ({ activityPoints, accountAddress, activityId }) => {
+          const groupByActivityCategory = Object.entries(
+            groupBy(groupedByUserId[userId], (item) => item.activityCategory)
+          ).map(([activityCategory, items]) => ({
+            activityCategory,
+            activities: items.map((item) => ({
+              activityId: item.activityId,
+              activityPoints: item.activityPoints,
+              accountAddress: item.accountAddress,
+            })),
+          }));
+
+          return {
+            accountAddress,
+            categories: groupByActivityCategory,
+          };
+        }
+      ),
+    })
+  );
+
+  // Ensure output directory exists
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  fs.writeFileSync(
+    path.join(outputDir, "results.json"),
+    JSON.stringify(withActivityPoints, null, 2)
+  );
+
+  yield* Effect.log("Results written to file");
+});
+
+await Effect.runPromise(runnable.pipe(Effect.provide(Logger.pretty)));


### PR DESCRIPTION
- Added Ociswap FlexPool and BasicPool position fetching & SwapEvent matching and filtering.

- Added CaviarNine SimplePool position fetching & SwapEvent matching and filtering.

- Added alt/DFP2 (such as XRD/DFP2, ASTRL/DFP2) DefiPlaza pools.

- Reworked LP position aggregation to split into two categories: lp and nativeLp.

Example: providing xUSDC/XRD liquidity to Ociswap used to result into one activityId `oci_lp_xrd-xusdc` with only xUSDC value counted towards usdValue. Now all LP is split into two categories, in this example that would be `oci_lp_xrd-xusdc` (which works as before, counting only non-native value: xUSDC value), and `oci_nativeLp_xrd-xusdc` (which only counts native resource value: XRD value).

- Include nativeness of resource in /address-validation/tokenNameMap.ts

- Pools added support for are just examples, and are the biggest pool(s) from their respective category:

BasicPool: EARLY/XRD, OCI/XRD
PrecisionPoolV2: OCI/XRD (to test multiple pools of same asset pair)
FlexPool: ILIS/XRD
DFP2 pools: XRD/DFP2 & ASTRL/DFP2
Shape Liquidity: FLOOP/XRD
SimplePools: REDDICKS/LSULP, FLOOP/XRD (to test multiple pools of same asset pair)