### PR TITLE
Update for all users when updating season points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ yarn-error.log*
 # Misc
 .DS_Store
 *.pem
+.idea/*

--- a/packages/api/src/incentives/dependencyLayer.ts
+++ b/packages/api/src/incentives/dependencyLayer.ts
@@ -72,6 +72,7 @@ import { CalculateSeasonPointsService } from "./season-points/calculateSeasonPoi
 import { GetSeasonByIdLive } from "./season/getSeasonById";
 import { GetActivitiesByWeekIdLive } from "./activity/getActivitiesByWeekId";
 import { UserActivityPointsService } from "./user/userActivityPoints";
+import { GetUsersPaginatedLive } from "./user/getUsersPaginated";
 import { UpdateWeekStatusService } from "./week/updateWeekStatus";
 import { AddSeasonPointsToUserService } from "./season-points/addSeasonPointsToUser";
 import { XrdBalanceLive } from "./account-balance/aggregateXrdBalance";
@@ -496,6 +497,10 @@ const getUserActivityPointsLive = UserActivityPointsService.Default.pipe(
   Layer.provide(dbClientLive)
 );
 
+const getUsersPaginatedLive = GetUsersPaginatedLive.pipe(
+  Layer.provide(dbClientLive)
+);
+
 const addSeasonPointsToUserLive = AddSeasonPointsToUserService.Default.pipe(
   Layer.provide(dbClientLive)
 );
@@ -520,6 +525,7 @@ const calculateSeasonPointsLive = CalculateSeasonPointsService.Default.pipe(
   Layer.provide(getWeekByIdLive),
   Layer.provide(getActivitiesByWeekIdLive),
   Layer.provide(getUserActivityPointsLive),
+  Layer.provide(getUsersPaginatedLive),
   Layer.provide(addSeasonPointsToUserLive),
   Layer.provide(updateWeekStatusLive),
   Layer.provide(getSeasonPointMultiplierLive),

--- a/packages/api/src/incentives/season-points/calculateSeasonPoints.ts
+++ b/packages/api/src/incentives/season-points/calculateSeasonPoints.ts
@@ -319,7 +319,7 @@ export class CalculateSeasonPointsService extends Effect.Service<CalculateSeason
           }));
 
           // Combine existing season points with zero season points for missing users
-          const completeUserSeasonPoints = [ ...zeroSeasonPoints,...userSeasonPoints,];
+          const completeUserSeasonPoints = [ ...zeroSeasonPoints,...userSeasonPoints];
 
           yield* Effect.log(`Adding season points for ${userSeasonPoints.length} users with calculated points and ${zeroSeasonPoints.length} users with zero points`);
 


### PR DESCRIPTION
Previously season point calculation was updating subset of users.   This meant if an user got some season points in previous run for the week, and in current calculation he doesn't ( either due to minimum balance not meet, or supply percentile decreased), then his points remained same from previous update.  He should get zero points as he didn't meet the criteria