### PR TITLE
feat: extend activity data with component addresses and verification

### DIFF
--- a/apps/admin/src/app/activities/[id]/page.tsx
+++ b/apps/admin/src/app/activities/[id]/page.tsx
@@ -257,6 +257,8 @@ function EditActivityPage() {
                 description: activity.description,
                 category: activity.category,
                 dapp: activity.dapp ?? '',
+                componentAddresses: activity.componentAddresses ?? [],
+                data: activity.data ?? {},
               }}
               onSubmit={handleUpdateActivity}
               isSubmitting={isSubmitting}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "db:push": "turbo run db:push:incentives",
     "db:create": "./postgres-init/init-db.sh",
     "db:reset": "./packages/db/scripts/reset.sh",
-    "queue:add": "pnpm --filter queue-helper run queue"
+    "queue:add": "pnpm --filter queue-helper run queue",
+    "verify:activities": "turbo run verify:activities"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -5,5 +5,11 @@
   "main": "./src/index.ts",
   "dependencies": {
     "zod": "catalog:"
+  },
+  "devDependencies": {
+    "tsx": "catalog:"
+  },
+  "scripts": {
+    "verify:activities": "tsx ./src/verifyActivity.ts"
   }
 }

--- a/packages/data/src/activities.ts
+++ b/packages/data/src/activities.ts
@@ -1,159 +1,193 @@
 import { ActivityCategoryId } from "./activityCategories";
 import type { ActivityId } from "./activityId";
+import { CaviarNineConstants } from "./dapps/caviarnine/constants";
 import { DappId } from "./dapps/dapps";
+import { DefiPlazaConstants } from "./dapps/defiPlaza/constants";
+import { OciswapConstants } from "./dapps/ociswap/constants";
+
+import { SurgeConstants } from "./dapps/surge/constants";
 
 export const activitiesData: {
   id: ActivityId;
   category: ActivityCategoryId;
   dApp: DappId;
+  componentAddresses?: string[];
 }[] = [
-  // DEX activities stables
+  /**
+   * CaviarNine LP activities
+   */
   {
     id: "c9_lp_xrd-xusdc",
     category: ActivityCategoryId.provideStablesLiquidityToDex,
     dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.shapeLiquidityPools.XRD_xUSDC.componentAddress,
+    ],
   },
-  {
-    id: "defiPlaza_lp_xrd-xusdc",
-    category: ActivityCategoryId.provideStablesLiquidityToDex,
-    dApp: DappId.defiPlaza,
-  },
-  {
-    id: "oci_lp_xrd-xusdc",
-    category: ActivityCategoryId.provideStablesLiquidityToDex,
-    dApp: DappId.ociswap,
-  },
-
   {
     id: "c9_lp_xrd-xusdt",
     category: ActivityCategoryId.provideStablesLiquidityToDex,
     dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.shapeLiquidityPools.XRD_xUSDT.componentAddress,
+    ],
   },
-  {
-    id: "defiPlaza_lp_xrd-xusdt",
-    category: ActivityCategoryId.provideStablesLiquidityToDex,
-    dApp: DappId.defiPlaza,
-  },
-  {
-    id: "oci_lp_xrd-xusdt",
-    category: ActivityCategoryId.provideStablesLiquidityToDex,
-    dApp: DappId.ociswap,
-  },
-  {
-    id: "surge_lp_xusdc",
-    category: ActivityCategoryId.provideStablesLiquidityToDex,
-    dApp: DappId.surge,
-  },
-
-  // DEX blue chip LP activities
   {
     id: "c9_lp_xeth-xrd",
     category: ActivityCategoryId.provideBlueChipLiquidityToDex,
     dApp: DappId.caviarnine,
-  },
-  {
-    id: "oci_lp_xeth-xrd",
-    category: ActivityCategoryId.provideBlueChipLiquidityToDex,
-    dApp: DappId.ociswap,
+    componentAddresses: [
+      CaviarNineConstants.shapeLiquidityPools.xETH_XRD.componentAddress,
+    ],
   },
   {
     id: "c9_lp_xrd-xwbtc",
     category: ActivityCategoryId.provideBlueChipLiquidityToDex,
     dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.shapeLiquidityPools.xwBTC_XRD.componentAddress,
+    ],
   },
-  {
-    id: "oci_lp_xrd-xwbtc",
-    category: ActivityCategoryId.provideBlueChipLiquidityToDex,
-    dApp: DappId.ociswap,
-  },
-  {
-    id: "defiPlaza_lp_xeth-xrd",
-    category: ActivityCategoryId.provideBlueChipLiquidityToDex,
-    dApp: DappId.defiPlaza,
-  },
-  {
-    id: "defiPlaza_lp_xrd-xwbtc",
-    category: ActivityCategoryId.provideBlueChipLiquidityToDex,
-    dApp: DappId.defiPlaza,
-  },
-
-  // DEX native LP activities
+  /**
+   * CaviarNine native LP activities
+   */
   {
     id: "c9_nativeLp_lsulp-xrd",
     category: ActivityCategoryId.provideNativeLiquidityToDex,
     dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.shapeLiquidityPools.LSULP_XRD.componentAddress,
+    ],
   },
   {
     id: "c9_nativeLp_hyperstake",
     category: ActivityCategoryId.provideNativeLiquidityToDex,
     dApp: DappId.caviarnine,
+    componentAddresses: [CaviarNineConstants.HLP.componentAddress],
   },
   {
     id: "c9_nativeLp_lsulp-reddicks",
     category: ActivityCategoryId.provideNativeLiquidityToDex,
     dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.simplePools.REDDICKS_LSULP.componentAddress,
+    ],
   },
   {
     id: "c9_nativeLp_floop-xrd",
     category: ActivityCategoryId.provideNativeLiquidityToDex,
     dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.simplePools.FLOOP_XRD.componentAddress,
+    ],
   },
+
+  /**
+   * DefiPlaza LP activities
+   */
+  {
+    id: "defiPlaza_lp_xrd-xusdc",
+    category: ActivityCategoryId.provideStablesLiquidityToDex,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.xUSDCPool.componentAddress],
+  },
+  {
+    id: "defiPlaza_lp_xrd-xusdt",
+    category: ActivityCategoryId.provideStablesLiquidityToDex,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.xUSDTPool.componentAddress],
+  },
+  {
+    id: "defiPlaza_lp_xeth-xrd",
+    category: ActivityCategoryId.provideBlueChipLiquidityToDex,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.xETHPool.componentAddress],
+  },
+  {
+    id: "defiPlaza_lp_xrd-xwbtc",
+    category: ActivityCategoryId.provideBlueChipLiquidityToDex,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.xwBTCPool.componentAddress],
+  },
+  /**
+   * DefiPlaza native LP activities
+   */
+  {
+    id: "defiPlaza_nativeLp_astrl-dfp2",
+    category: ActivityCategoryId.provideNativeLiquidityToDex,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.ASTRLPool.componentAddress],
+  },
+
+  /**
+   * Ociswap LP activities
+   */
+  {
+    id: "oci_lp_xrd-xusdc",
+    category: ActivityCategoryId.provideStablesLiquidityToDex,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.pools.xUSDC_XRD.componentAddress],
+  },
+  {
+    id: "oci_lp_xrd-xusdt",
+    category: ActivityCategoryId.provideStablesLiquidityToDex,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.pools.xUSDT_XRD.componentAddress],
+  },
+  {
+    id: "oci_lp_xeth-xrd",
+    category: ActivityCategoryId.provideBlueChipLiquidityToDex,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.pools.xETH_XRD.componentAddress],
+  },
+  {
+    id: "oci_lp_xrd-xwbtc",
+    category: ActivityCategoryId.provideBlueChipLiquidityToDex,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.pools.xwBTC_XRD.componentAddress],
+  },
+
+  /**
+   * Ociswap native LP activities
+   */
   {
     id: "oci_nativeLp_oci-xrd",
     category: ActivityCategoryId.provideNativeLiquidityToDex,
     dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.basicPools.OCI_XRD.componentAddress],
   },
   {
     id: "oci_nativeLp_ilis-xrd",
     category: ActivityCategoryId.provideNativeLiquidityToDex,
     dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.flexPools.ILIS_XRD.componentAddress],
   },
   {
     id: "oci_nativeLp_early-xrd",
     category: ActivityCategoryId.provideNativeLiquidityToDex,
     dApp: DappId.ociswap,
-  },
-  {
-    id: "defiPlaza_nativeLp_astrl-dfp2",
-    category: ActivityCategoryId.provideNativeLiquidityToDex,
-    dApp: DappId.defiPlaza,
-  },
-  {
-    id: "defiPlaza_nativeLp_dfp2-xrd",
-    category: ActivityCategoryId.provideNativeLiquidityToDex,
-    dApp: DappId.defiPlaza,
+    componentAddresses: [
+      OciswapConstants.basicPools.EARLY_XRD.componentAddress,
+    ],
   },
 
-  // Lending activities
+  /**
+   * Surge LP activities
+   */
+  {
+    id: "surge_lp_xusdc",
+    category: ActivityCategoryId.provideStablesLiquidityToDex,
+    dApp: DappId.surge,
+    componentAddresses: [SurgeConstants.marginPool.componentAddress],
+  },
+
+  /**
+   * Root lending activities
+   */
   {
     id: "root_lend_xusdc",
     category: ActivityCategoryId.lendingStables,
     dApp: DappId.root,
-  },
-  {
-    id: "weft_lend_xusdc",
-    category: ActivityCategoryId.lendingStables,
-    dApp: DappId.weft,
-  },
-  {
-    id: "weft_lend_xusdt",
-    category: ActivityCategoryId.lendingStables,
-    dApp: DappId.weft,
-  },
-  {
-    id: "weft_lend_xwbtc",
-    category: ActivityCategoryId.lendingStables,
-    dApp: DappId.weft,
-  },
-  {
-    id: "weft_lend_xeth",
-    category: ActivityCategoryId.lendingStables,
-    dApp: DappId.weft,
-  },
-  {
-    id: "weft_lend_xrd",
-    category: ActivityCategoryId.lendingStables,
-    dApp: DappId.weft,
   },
   {
     id: "root_lend_xusdt",
@@ -181,14 +215,47 @@ export const activitiesData: {
     dApp: DappId.root,
   },
 
-  // Network activities
+  /**
+   * Weft lending activities
+   */
+  {
+    id: "weft_lend_xusdc",
+    category: ActivityCategoryId.lendingStables,
+    dApp: DappId.weft,
+  },
+  {
+    id: "weft_lend_xusdt",
+    category: ActivityCategoryId.lendingStables,
+    dApp: DappId.weft,
+  },
+  {
+    id: "weft_lend_xwbtc",
+    category: ActivityCategoryId.lendingStables,
+    dApp: DappId.weft,
+  },
+  {
+    id: "weft_lend_xeth",
+    category: ActivityCategoryId.lendingStables,
+    dApp: DappId.weft,
+  },
+  {
+    id: "weft_lend_xrd",
+    category: ActivityCategoryId.lendingStables,
+    dApp: DappId.weft,
+  },
+
+  /**
+   * Network activities
+   */
   {
     id: "txFees",
     category: ActivityCategoryId.transactionFees,
     dApp: DappId.radix,
   },
 
-  // Season multiplier Hodl XRD activities for native assets
+  /**
+   * Radix hold activities
+   */
   {
     id: "hold_xrd",
     category: ActivityCategoryId.maintainXrdBalance,
@@ -210,114 +277,163 @@ export const activitiesData: {
     dApp: DappId.radix,
   },
 
-  // Season multiplier Hodl XRD activities through DEX LP positions
+  /**
+   * CaviarNine hold activities
+   */
   {
     id: "c9_hold_xrd-xusdc",
     category: ActivityCategoryId.maintainXrdBalance,
     dApp: DappId.caviarnine,
-  },
-  {
-    id: "defiPlaza_hold_xrd-xusdc",
-    category: ActivityCategoryId.maintainXrdBalance,
-    dApp: DappId.defiPlaza,
-  },
-  {
-    id: "oci_hold_xrd-xusdc",
-    category: ActivityCategoryId.maintainXrdBalance,
-    dApp: DappId.ociswap,
+    componentAddresses: [
+      CaviarNineConstants.shapeLiquidityPools.XRD_xUSDC.componentAddress,
+    ],
   },
   {
     id: "c9_hold_xrd-xusdt",
     category: ActivityCategoryId.maintainXrdBalance,
     dApp: DappId.caviarnine,
-  },
-  {
-    id: "defiPlaza_hold_xrd-xusdt",
-    category: ActivityCategoryId.maintainXrdBalance,
-    dApp: DappId.defiPlaza,
-  },
-  {
-    id: "oci_hold_xrd-xusdt",
-    category: ActivityCategoryId.maintainXrdBalance,
-    dApp: DappId.ociswap,
+    componentAddresses: [
+      CaviarNineConstants.shapeLiquidityPools.XRD_xUSDT.componentAddress,
+    ],
   },
   {
     id: "c9_hold_xeth-xrd",
     category: ActivityCategoryId.maintainXrdBalance,
     dApp: DappId.caviarnine,
-  },
-  {
-    id: "defiPlaza_hold_xeth-xrd",
-    category: ActivityCategoryId.maintainXrdBalance,
-    dApp: DappId.defiPlaza,
-  },
-  {
-    id: "oci_hold_xeth-xrd",
-    category: ActivityCategoryId.maintainXrdBalance,
-    dApp: DappId.ociswap,
+    componentAddresses: [
+      CaviarNineConstants.shapeLiquidityPools.xETH_XRD.componentAddress,
+    ],
   },
   {
     id: "c9_hold_xrd-xwbtc",
     category: ActivityCategoryId.maintainXrdBalance,
     dApp: DappId.caviarnine,
-  },
-  {
-    id: "defiPlaza_hold_xrd-xwbtc",
-    category: ActivityCategoryId.maintainXrdBalance,
-    dApp: DappId.defiPlaza,
-  },
-  {
-    id: "oci_hold_xrd-xwbtc",
-    category: ActivityCategoryId.maintainXrdBalance,
-    dApp: DappId.ociswap,
+    componentAddresses: [
+      CaviarNineConstants.shapeLiquidityPools.xwBTC_XRD.componentAddress,
+    ],
   },
   {
     id: "c9_hold_lsulp-xrd",
     category: ActivityCategoryId.maintainXrdBalance,
     dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.shapeLiquidityPools.LSULP_XRD.componentAddress,
+    ],
   },
   {
     id: "c9_hold_hyperstake",
     category: ActivityCategoryId.maintainXrdBalance,
     dApp: DappId.caviarnine,
-  },
-  {
-    id: "oci_hold_early-xrd",
-    category: ActivityCategoryId.maintainXrdBalance,
-    dApp: DappId.ociswap,
-  },
-  {
-    id: "oci_hold_ilis-xrd",
-    category: ActivityCategoryId.maintainXrdBalance,
-    dApp: DappId.ociswap,
-  },
-  {
-    id: "oci_hold_oci-xrd",
-    category: ActivityCategoryId.maintainXrdBalance,
-    dApp: DappId.ociswap,
-  },
-  {
-    id: "defiPlaza_hold_astrl-dfp2",
-    category: ActivityCategoryId.maintainXrdBalance,
-    dApp: DappId.defiPlaza,
-  },
-  {
-    id: "defiPlaza_hold_dfp2-xrd",
-    category: ActivityCategoryId.maintainXrdBalance,
-    dApp: DappId.defiPlaza,
+    componentAddresses: [CaviarNineConstants.HLP.componentAddress],
   },
   {
     id: "c9_hold_floop-xrd",
     category: ActivityCategoryId.maintainXrdBalance,
     dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.simplePools.FLOOP_XRD.componentAddress,
+    ],
   },
   {
     id: "c9_hold_lsulp-reddicks",
     category: ActivityCategoryId.maintainXrdBalance,
     dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.simplePools.REDDICKS_LSULP.componentAddress,
+    ],
   },
 
-  // Season multiplier Hodl activities XRD activities through lending positions
+  /**
+   * DefiPlaza hold activities
+   */
+  {
+    id: "defiPlaza_hold_xrd-xusdc",
+    category: ActivityCategoryId.maintainXrdBalance,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.xUSDCPool.componentAddress],
+  },
+  {
+    id: "defiPlaza_hold_xrd-xusdt",
+    category: ActivityCategoryId.maintainXrdBalance,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.xUSDTPool.componentAddress],
+  },
+  {
+    id: "defiPlaza_hold_xeth-xrd",
+    category: ActivityCategoryId.maintainXrdBalance,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.xETHPool.componentAddress],
+  },
+  {
+    id: "defiPlaza_hold_xrd-xwbtc",
+    category: ActivityCategoryId.maintainXrdBalance,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.xwBTCPool.componentAddress],
+  },
+  {
+    id: "defiPlaza_hold_astrl-dfp2",
+    category: ActivityCategoryId.maintainXrdBalance,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.ASTRLPool.componentAddress],
+  },
+  {
+    id: "defiPlaza_hold_dfp2-xrd",
+    category: ActivityCategoryId.maintainXrdBalance,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.XRDPool.componentAddress],
+  },
+
+  /**
+   * Ociswap hold activities
+   */
+  {
+    id: "oci_hold_xrd-xusdc",
+    category: ActivityCategoryId.maintainXrdBalance,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.pools.xUSDC_XRD.componentAddress],
+  },
+  {
+    id: "oci_hold_xrd-xusdt",
+    category: ActivityCategoryId.maintainXrdBalance,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.pools.xUSDT_XRD.componentAddress],
+  },
+  {
+    id: "oci_hold_xeth-xrd",
+    category: ActivityCategoryId.maintainXrdBalance,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.pools.xETH_XRD.componentAddress],
+  },
+  {
+    id: "oci_hold_xrd-xwbtc",
+    category: ActivityCategoryId.maintainXrdBalance,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.pools.xwBTC_XRD.componentAddress],
+  },
+  {
+    id: "oci_hold_early-xrd",
+    category: ActivityCategoryId.maintainXrdBalance,
+    dApp: DappId.ociswap,
+    componentAddresses: [
+      OciswapConstants.basicPools.EARLY_XRD.componentAddress,
+    ],
+  },
+  {
+    id: "oci_hold_ilis-xrd",
+    category: ActivityCategoryId.maintainXrdBalance,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.flexPools.ILIS_XRD.componentAddress],
+  },
+  {
+    id: "oci_hold_oci-xrd",
+    category: ActivityCategoryId.maintainXrdBalance,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.basicPools.OCI_XRD.componentAddress],
+  },
+
+  /**
+   * Root hold activities
+   */
   {
     id: "root_hold_xrd",
     category: ActivityCategoryId.maintainXrdBalance,
@@ -328,6 +444,10 @@ export const activitiesData: {
     category: ActivityCategoryId.maintainXrdBalance,
     dApp: DappId.root,
   },
+
+  /**
+   * Weft hold activities
+   */
   {
     id: "weft_hold_xrd",
     category: ActivityCategoryId.maintainXrdBalance,
@@ -348,6 +468,164 @@ export const activitiesData: {
     category: ActivityCategoryId.maintainXrdBalance,
     dApp: DappId.weft,
   },
+
+  /**
+   * CaviarNine trading activities
+   */
+  {
+    id: "c9_trade_xrd-xusdc",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.shapeLiquidityPools.XRD_xUSDC.componentAddress,
+    ],
+  },
+  {
+    id: "c9_trade_xrd-xusdt",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.shapeLiquidityPools.XRD_xUSDT.componentAddress,
+    ],
+  },
+  {
+    id: "c9_trade_xeth-xrd",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.shapeLiquidityPools.xETH_XRD.componentAddress,
+    ],
+  },
+  {
+    id: "c9_trade_xrd-xwbtc",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.shapeLiquidityPools.xwBTC_XRD.componentAddress,
+    ],
+  },
+  {
+    id: "c9_trade_lsulp-xrd",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.shapeLiquidityPools.LSULP_XRD.componentAddress,
+    ],
+  },
+  {
+    id: "c9_trade_hyperstake",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.caviarnine,
+    componentAddresses: [CaviarNineConstants.HLP.componentAddress],
+  },
+  {
+    id: "c9_trade_lsulp-reddicks",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.simplePools.REDDICKS_LSULP.componentAddress,
+    ],
+  },
+  {
+    id: "c9_trade_floop-xrd",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.caviarnine,
+    componentAddresses: [
+      CaviarNineConstants.simplePools.FLOOP_XRD.componentAddress,
+    ],
+  },
+
+  /**
+   * DefiPlaza trading activities
+   */
+  {
+    id: "defiPlaza_trade_xrd-xusdc",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.xUSDCPool.componentAddress],
+  },
+  {
+    id: "defiPlaza_trade_xeth-xrd",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.xETHPool.componentAddress],
+  },
+  {
+    id: "defiPlaza_trade_xrd-xwbtc",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.xwBTCPool.componentAddress],
+  },
+  {
+    id: "defiPlaza_trade_xrd-xusdt",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.xUSDTPool.componentAddress],
+  },
+  {
+    id: "defiPlaza_trade_astrl-dfp2",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.ASTRLPool.componentAddress],
+  },
+  {
+    id: "defiPlaza_trade_dfp2-xrd",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.defiPlaza,
+    componentAddresses: [DefiPlazaConstants.XRDPool.componentAddress],
+  },
+
+  /**
+   * Ociswap trading activities
+   */
+  {
+    id: "oci_trade_xrd-xusdt",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.pools.xUSDT_XRD.componentAddress],
+  },
+  {
+    id: "oci_trade_xeth-xrd",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.pools.xETH_XRD.componentAddress],
+  },
+  {
+    id: "oci_trade_xrd-xwbtc",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.pools.xwBTC_XRD.componentAddress],
+  },
+  {
+    id: "oci_trade_oci-xrd",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.basicPools.OCI_XRD.componentAddress],
+  },
+  {
+    id: "oci_trade_ilis-xrd",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.flexPools.ILIS_XRD.componentAddress],
+  },
+  {
+    id: "oci_trade_early-xrd",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.ociswap,
+    componentAddresses: [
+      OciswapConstants.basicPools.EARLY_XRD.componentAddress,
+    ],
+  },
+  {
+    id: "oci_trade_xrd-xusdc",
+    category: ActivityCategoryId.tradingVolume,
+    dApp: DappId.ociswap,
+    componentAddresses: [OciswapConstants.pools.xUSDC_XRD.componentAddress],
+  },
+
+  /**
+   * Component calls
+   */
   {
     id: "componentCalls",
     category: ActivityCategoryId.componentCalls,
@@ -359,111 +637,5 @@ export const activitiesData: {
     id: "common",
     category: ActivityCategoryId.common,
     dApp: DappId.radix,
-  },
-  // DEX trading activities
-  {
-    id: "c9_trade_xrd-xusdc",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.caviarnine,
-  },
-  {
-    id: "c9_trade_xrd-xusdt",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.caviarnine,
-  },
-  {
-    id: "c9_trade_xeth-xrd",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.caviarnine,
-  },
-  {
-    id: "c9_trade_xrd-xwbtc",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.caviarnine,
-  },
-  {
-    id: "c9_trade_lsulp-xrd",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.caviarnine,
-  },
-  {
-    id: "c9_trade_hyperstake",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.caviarnine,
-  },
-  {
-    id: "defiPlaza_trade_xrd-xusdc",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.defiPlaza,
-  },
-  {
-    id: "defiPlaza_trade_xeth-xrd",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.defiPlaza,
-  },
-  {
-    id: "defiPlaza_trade_xrd-xwbtc",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.defiPlaza,
-  },
-  {
-    id: "defiPlaza_trade_xrd-xusdt",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.defiPlaza,
-  },
-  {
-    id: "oci_trade_xrd-xusdc",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.ociswap,
-  },
-  {
-    id: "oci_trade_xrd-xusdt",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.ociswap,
-  },
-  {
-    id: "oci_trade_xeth-xrd",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.ociswap,
-  },
-  {
-    id: "oci_trade_xrd-xwbtc",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.ociswap,
-  },
-  {
-    id: "c9_trade_lsulp-reddicks",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.caviarnine,
-  },
-  {
-    id: "c9_trade_floop-xrd",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.caviarnine,
-  },
-  {
-    id: "oci_trade_oci-xrd",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.ociswap,
-  },
-  {
-    id: "oci_trade_ilis-xrd",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.ociswap,
-  },
-  {
-    id: "oci_trade_early-xrd",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.ociswap,
-  },
-  {
-    id: "defiPlaza_trade_astrl-dfp2",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.defiPlaza,
-  },
-  {
-    id: "defiPlaza_trade_dfp2-xrd",
-    category: ActivityCategoryId.tradingVolume,
-    dApp: DappId.defiPlaza,
   },
 ];

--- a/packages/data/src/activityId.ts
+++ b/packages/data/src/activityId.ts
@@ -32,7 +32,6 @@ export const ActivityId = {
   c9_nativeLp_hyperstake: "c9_nativeLp_hyperstake",
 
   "defiPlaza_nativeLp_astrl-dfp2": "defiPlaza_nativeLp_astrl-dfp2",
-  "defiPlaza_nativeLp_dfp2-xrd": "defiPlaza_nativeLp_dfp2-xrd",
 
   /**
    * Hold XRD/LSU/LSULP/HLP activities (multiplier activities)

--- a/packages/data/src/verifyActivity.ts
+++ b/packages/data/src/verifyActivity.ts
@@ -1,0 +1,16 @@
+import { ActivityId } from "./activityId";
+import { activitiesData } from "./activities";
+
+const verifyActivity = (): void => {
+  for (const activityId of Object.values(ActivityId)) {
+    const activity = activitiesData.find(
+      (activity) => activity.id === activityId
+    );
+    if (!activity) {
+      throw new Error(`Activity ${activityId} not found`);
+    }
+  }
+  console.log("All activities verified");
+};
+
+verifyActivity();

--- a/packages/db/src/incentives/drizzle/0022_nasty_electro.sql
+++ b/packages/db/src/incentives/drizzle/0022_nasty_electro.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "activity" ADD COLUMN "component_addresses" jsonb;--> statement-breakpoint
+ALTER TABLE "activity" ADD COLUMN "data" jsonb;

--- a/packages/db/src/incentives/drizzle/meta/0022_snapshot.json
+++ b/packages/db/src/incentives/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,1203 @@
+{
+  "id": "736f35c6-8a7c-4184-a26c-560f5d98a788",
+  "prevId": "2ebb555b-6cca-4f4e-aa06-8c33e438c461",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_activity_points": {
+      "name": "account_activity_points",
+      "schema": "",
+      "columns": {
+        "account_address": {
+          "name": "account_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_id": {
+          "name": "week_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_points": {
+          "name": "activity_points",
+          "type": "numeric(18, 6)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_activity_points_account_address_account_address_fk": {
+          "name": "account_activity_points_account_address_account_address_fk",
+          "tableFrom": "account_activity_points",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_activity_points_week_id_week_id_fk": {
+          "name": "account_activity_points_week_id_week_id_fk",
+          "tableFrom": "account_activity_points",
+          "tableTo": "week",
+          "columnsFrom": [
+            "week_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_activity_points_activity_id_activity_id_fk": {
+          "name": "account_activity_points_activity_id_activity_id_fk",
+          "tableFrom": "account_activity_points",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_activity_points_account_address_week_id_activity_id_pk": {
+          "name": "account_activity_points_account_address_week_id_activity_id_pk",
+          "columns": [
+            "account_address",
+            "week_id",
+            "activity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.account_balances": {
+      "name": "account_balances",
+      "schema": "",
+      "columns": {
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_address": {
+          "name": "account_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_account_balances_timestamp": {
+          "name": "idx_account_balances_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_balances_account": {
+          "name": "idx_account_balances_account",
+          "columns": [
+            {
+              "expression": "account_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_balances_account_address_account_address_fk": {
+          "name": "account_balances_account_address_account_address_fk",
+          "tableFrom": "account_balances",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_balances_account_address_timestamp_pk": {
+          "name": "account_balances_account_address_timestamp_pk",
+          "columns": [
+            "account_address",
+            "timestamp"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dapp": {
+          "name": "dapp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "component_addresses": {
+          "name": "component_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_category_activity_categories_id_fk": {
+          "name": "activity_category_activity_categories_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "activity_categories",
+          "columnsFrom": [
+            "category"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_dapp_dapp_id_fk": {
+          "name": "activity_dapp_dapp_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "dapp",
+          "columnsFrom": [
+            "dapp"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.activity_categories": {
+      "name": "activity_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.activity_category_weeks": {
+      "name": "activity_category_weeks",
+      "schema": "",
+      "columns": {
+        "activity_category_id": {
+          "name": "activity_category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_id": {
+          "name": "week_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points_pool": {
+          "name": "points_pool",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_category_weeks_activity_category_id_activity_categories_id_fk": {
+          "name": "activity_category_weeks_activity_category_id_activity_categories_id_fk",
+          "tableFrom": "activity_category_weeks",
+          "tableTo": "activity_categories",
+          "columnsFrom": [
+            "activity_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_category_weeks_week_id_week_id_fk": {
+          "name": "activity_category_weeks_week_id_week_id_fk",
+          "tableFrom": "activity_category_weeks",
+          "tableTo": "week",
+          "columnsFrom": [
+            "week_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_category_week_pk": {
+          "name": "activity_category_week_pk",
+          "columns": [
+            "week_id",
+            "activity_category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.activity_week": {
+      "name": "activity_week",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_id": {
+          "name": "week_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multiplier": {
+          "name": "multiplier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_week_activity_id_activity_id_fk": {
+          "name": "activity_week_activity_id_activity_id_fk",
+          "tableFrom": "activity_week",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_week_week_id_week_id_fk": {
+          "name": "activity_week_week_id_week_id_fk",
+          "tableFrom": "activity_week",
+          "tableTo": "week",
+          "columnsFrom": [
+            "week_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_week_pk": {
+          "name": "activity_week_pk",
+          "columns": [
+            "activity_id",
+            "week_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.challenge": {
+      "name": "challenge",
+      "schema": "",
+      "columns": {
+        "challenge": {
+          "name": "challenge",
+          "type": "char(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.component_calls": {
+      "name": "component_calls",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "component_calls_user_id_user_id_fk": {
+          "name": "component_calls_user_id_user_id_fk",
+          "tableFrom": "component_calls",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "component_calls_user_id_timestamp_pk": {
+          "name": "component_calls_user_id_timestamp_pk",
+          "columns": [
+            "user_id",
+            "timestamp"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.config": {
+      "name": "config",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.dapp": {
+      "name": "dapp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.event": {
+      "name": "event",
+      "schema": "",
+      "columns": {
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_index": {
+          "name": "event_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dApp": {
+          "name": "dApp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_version": {
+          "name": "state_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_emitter": {
+          "name": "global_emitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_address": {
+          "name": "package_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint": {
+          "name": "blueprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "event_transaction_id_event_index_pk": {
+          "name": "event_transaction_id_event_index_pk",
+          "columns": [
+            "transaction_id",
+            "event_index"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.season_points_multiplier": {
+      "name": "season_points_multiplier",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_id": {
+          "name": "week_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multiplier": {
+          "name": "multiplier",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cumulative_twa_balance": {
+          "name": "cumulative_twa_balance",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_twa_balance": {
+          "name": "total_twa_balance",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "season_points_multiplier_user_id_user_id_fk": {
+          "name": "season_points_multiplier_user_id_user_id_fk",
+          "tableFrom": "season_points_multiplier",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "season_points_multiplier_week_id_week_id_fk": {
+          "name": "season_points_multiplier_week_id_week_id_fk",
+          "tableFrom": "season_points_multiplier",
+          "tableTo": "week",
+          "columnsFrom": [
+            "week_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "season_points_multiplier_user_id_week_id_pk": {
+          "name": "season_points_multiplier_user_id_week_id_pk",
+          "columns": [
+            "user_id",
+            "week_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.season": {
+      "name": "season",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "season_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upcoming'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.snapshot": {
+      "name": "snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "snapshot_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.trading_volume": {
+      "name": "trading_volume",
+      "schema": "",
+      "columns": {
+        "account_address": {
+          "name": "account_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "trading_volume_account_address_account_address_fk": {
+          "name": "trading_volume_account_address_account_address_fk",
+          "tableFrom": "trading_volume",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trading_volume_timestamp_account_address_pk": {
+          "name": "trading_volume_timestamp_account_address_pk",
+          "columns": [
+            "timestamp",
+            "account_address"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.transaction_fees": {
+      "name": "transaction_fees",
+      "schema": "",
+      "columns": {
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_address": {
+          "name": "account_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_fees_account_address_account_address_fk": {
+          "name": "transaction_fees_account_address_account_address_fk",
+          "tableFrom": "transaction_fees",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_address"
+          ],
+          "columnsTo": [
+            "address"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transaction_fees_timestamp_account_address_transaction_id_pk": {
+          "name": "transaction_fees_timestamp_account_address_transaction_id_pk",
+          "columns": [
+            "timestamp",
+            "account_address",
+            "transaction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identity_address": {
+          "name": "identity_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_identity_address_unique": {
+          "name": "user_identity_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity_address"
+          ]
+        }
+      }
+    },
+    "public.user_season_points": {
+      "name": "user_season_points",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_id": {
+          "name": "week_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "numeric(18, 6)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_season_points_user_id_user_id_fk": {
+          "name": "user_season_points_user_id_user_id_fk",
+          "tableFrom": "user_season_points",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_season_points_season_id_season_id_fk": {
+          "name": "user_season_points_season_id_season_id_fk",
+          "tableFrom": "user_season_points",
+          "tableTo": "season",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_season_points_week_id_week_id_fk": {
+          "name": "user_season_points_week_id_week_id_fk",
+          "tableFrom": "user_season_points",
+          "tableTo": "week",
+          "columnsFrom": [
+            "week_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_season_points_user_id_season_id_week_id_pk": {
+          "name": "user_season_points_user_id_season_id_week_id_pk",
+          "columns": [
+            "user_id",
+            "season_id",
+            "week_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.verification_token": {
+      "name": "verification_token",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_token_identifier_token_pk": {
+          "name": "verification_token_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.week": {
+      "name": "week",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed": {
+          "name": "processed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "week_season_id_season_id_fk": {
+          "name": "week_season_id_season_id_fk",
+          "tableFrom": "week",
+          "tableTo": "season",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.activity_week_status": {
+      "name": "activity_week_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.season_status": {
+      "name": "season_status",
+      "schema": "public",
+      "values": [
+        "upcoming",
+        "active",
+        "completed"
+      ]
+    },
+    "public.snapshot_status": {
+      "name": "snapshot_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/incentives/drizzle/meta/_journal.json
+++ b/packages/db/src/incentives/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1753101987847,
       "tag": "0021_cold_agent_brand",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1753188065407,
+      "tag": "0022_nasty_electro",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/incentives/schema.ts
+++ b/packages/db/src/incentives/schema.ts
@@ -180,6 +180,8 @@ export const activities = createTable("activity", {
     .notNull()
     .references(() => activityCategories.id, { onDelete: "cascade" }),
   dapp: text("dapp").references(() => dapps.id),
+  componentAddresses: jsonb("component_addresses").$defaultFn(() => []),
+  data: jsonb("data").$defaultFn(() => ({})),
 });
 
 export const activitiesRelations = relations(activities, ({ many, one }) => ({
@@ -336,7 +338,10 @@ export const accountActivityPoints = createTable(
     activityId: text("activity_id")
       .notNull()
       .references(() => activities.id, { onDelete: "cascade" }),
-    activityPoints: decimal("activity_points", { precision: 18, scale: 6 }).notNull(),
+    activityPoints: decimal("activity_points", {
+      precision: 18,
+      scale: 6,
+    }).notNull(),
   },
   (table) => ({
     pk: primaryKey({

--- a/packages/db/src/incentives/seed/activities.ts
+++ b/packages/db/src/incentives/seed/activities.ts
@@ -35,6 +35,7 @@ export const seedActivities = async () => {
         id: activity.id,
         category: activity.category,
         dapp: activity.dApp,
+        componentAddresses: activity.componentAddresses ?? [],
       }))
     )
     .returning()
@@ -44,6 +45,7 @@ export const seedActivities = async () => {
         name: sql`excluded.name`,
         category: sql`excluded.category`,
         dapp: sql`excluded.dapp`,
+        componentAddresses: sql`excluded.component_addresses`,
       },
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1068,6 +1068,10 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 3.24.2
+    devDependencies:
+      tsx:
+        specifier: 'catalog:'
+        version: 4.19.3
 
   packages/db:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -40,6 +40,9 @@
     "db:push:incentives": {
       "cache": false,
       "persistent": true
+    },
+    "verify:activities": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## Summary
- Added `componentAddresses` field to activities schema and data structure
- Included specific component addresses for all DeFi activities across CaviarNine, DefiPlaza, and Ociswap platforms
- Created new `verifyActivity.ts` script for data validation and integrity checks
- Updated database migration scripts and seed data to support new schema

## Test plan
- [ ] Run database migrations to ensure schema changes apply correctly
- [ ] Execute seed script to verify activities are populated with component addresses
- [ ] Run the new verification script: `pnpm verify:activities`
- [ ] Validate that all activities have appropriate component addresses where expected

🤖 Generated with [Claude Code](https://claude.ai/code)