### PR TITLE
feat: add activity configuration UI with collapsible sidebar

### DIFF
--- a/apps/admin/src/app/activities/page.tsx
+++ b/apps/admin/src/app/activities/page.tsx
@@ -17,7 +17,16 @@ import { Separator } from '~/components/ui/separator';
 import { Input } from '~/components/ui/input';
 import { api } from '~/trpc/react';
 
-type SortField = 'id' | 'name' | 'description' | 'category' | 'dapp';
+type SortField =
+  | 'id'
+  | 'name'
+  | 'description'
+  | 'category'
+  | 'dapp'
+  | 'componentAddresses'
+  | 'showOnEarnPage'
+  | 'ap'
+  | 'multiplier';
 type SortDirection = 'asc' | 'desc';
 
 function ManageActivitiesPage() {
@@ -92,6 +101,38 @@ function ManageActivitiesPage() {
         case 'dapp':
           aValue = a.dapp || '';
           bValue = b.dapp || '';
+          break;
+        case 'componentAddresses':
+          aValue =
+            (a.componentAddresses as string[])?.length?.toString() || '0';
+          bValue =
+            (b.componentAddresses as string[])?.length?.toString() || '0';
+          break;
+        case 'showOnEarnPage':
+          aValue =
+            ((a.data as { showOnEarnPage?: boolean })?.showOnEarnPage ?? true)
+              ? 'true'
+              : 'false';
+          bValue =
+            ((b.data as { showOnEarnPage?: boolean })?.showOnEarnPage ?? true)
+              ? 'true'
+              : 'false';
+          break;
+        case 'ap':
+          aValue =
+            ((a.data as { ap?: boolean })?.ap ?? false) ? 'true' : 'false';
+          bValue =
+            ((b.data as { ap?: boolean })?.ap ?? false) ? 'true' : 'false';
+          break;
+        case 'multiplier':
+          aValue =
+            ((a.data as { multiplier?: boolean })?.multiplier ?? false)
+              ? 'true'
+              : 'false';
+          bValue =
+            ((b.data as { multiplier?: boolean })?.multiplier ?? false)
+              ? 'true'
+              : 'false';
           break;
       }
 
@@ -178,12 +219,48 @@ function ManageActivitiesPage() {
                 </div>
               </TableHead>
               <TableHead
-                className="cursor-pointer hover:bg-muted/50"
+                className="cursor-pointer hover:bg-muted/50 border-r"
                 onClick={() => handleSort('dapp')}
               >
                 <div className="flex items-center">
                   Dapp
                   {getSortIcon('dapp')}
+                </div>
+              </TableHead>
+              <TableHead
+                className="cursor-pointer hover:bg-muted/50 border-r"
+                onClick={() => handleSort('componentAddresses')}
+              >
+                <div className="flex items-center">
+                  Component Addresses
+                  {getSortIcon('componentAddresses')}
+                </div>
+              </TableHead>
+              <TableHead
+                className="cursor-pointer hover:bg-muted/50 border-r"
+                onClick={() => handleSort('showOnEarnPage')}
+              >
+                <div className="flex items-center">
+                  Show on Earn Page
+                  {getSortIcon('showOnEarnPage')}
+                </div>
+              </TableHead>
+              <TableHead
+                className="cursor-pointer hover:bg-muted/50 border-r"
+                onClick={() => handleSort('ap')}
+              >
+                <div className="flex items-center">
+                  AP
+                  {getSortIcon('ap')}
+                </div>
+              </TableHead>
+              <TableHead
+                className="cursor-pointer hover:bg-muted/50"
+                onClick={() => handleSort('multiplier')}
+              >
+                <div className="flex items-center">
+                  Multiplier
+                  {getSortIcon('multiplier')}
                 </div>
               </TableHead>
             </TableRow>
@@ -208,12 +285,74 @@ function ManageActivitiesPage() {
                   <TableCell className="border-r">
                     <Badge variant="outline">{activity.category}</Badge>
                   </TableCell>
-                  <TableCell>{activity.dapp || '-'}</TableCell>
+                  <TableCell className="border-r">
+                    {activity.dapp || '-'}
+                  </TableCell>
+                  <TableCell className="border-r max-w-xs">
+                    <div className="space-y-1">
+                      {(activity.componentAddresses as string[])?.length > 0
+                        ? (activity.componentAddresses as string[]).map(
+                            (address, index) => (
+                              <div
+                                key={address}
+                                className="text-xs font-mono truncate"
+                                title={address}
+                              >
+                                {address}
+                              </div>
+                            ),
+                          )
+                        : '-'}
+                    </div>
+                  </TableCell>
+                  <TableCell className="border-r">
+                    <Badge
+                      variant={
+                        ((activity.data as { showOnEarnPage?: boolean })
+                          ?.showOnEarnPage ?? true)
+                          ? 'default'
+                          : 'secondary'
+                      }
+                    >
+                      {((activity.data as { showOnEarnPage?: boolean })
+                        ?.showOnEarnPage ?? true)
+                        ? 'Yes'
+                        : 'No'}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="border-r">
+                    <Badge
+                      variant={
+                        ((activity.data as { ap?: boolean })?.ap ?? false)
+                          ? 'default'
+                          : 'secondary'
+                      }
+                    >
+                      {((activity.data as { ap?: boolean })?.ap ?? false)
+                        ? 'Yes'
+                        : 'No'}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={
+                        ((activity.data as { multiplier?: boolean })
+                          ?.multiplier ?? false)
+                          ? 'default'
+                          : 'secondary'
+                      }
+                    >
+                      {((activity.data as { multiplier?: boolean })
+                        ?.multiplier ?? false)
+                        ? 'Yes'
+                        : 'No'}
+                    </Badge>
+                  </TableCell>
                 </TableRow>
               ))
             ) : (
               <TableRow>
-                <TableCell colSpan={5} className="h-24 text-center">
+                <TableCell colSpan={9} className="h-24 text-center">
                   {searchTerm
                     ? 'No activities found matching your search.'
                     : 'No activities defined yet.'}

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import '../styles/globals.css';
 import { ThemeProvider } from '../components/theme-provider';
-import { Sidebar } from '../components/sidebar';
+import { Layout } from '../components/layout';
 import { TRPCReactProvider } from '~/trpc/react';
 import { Toaster } from 'sonner';
 
@@ -23,10 +23,7 @@ export default function RootLayout({
       <body className={inter.className}>
         <TRPCReactProvider>
           <ThemeProvider attribute="class" defaultTheme="dark">
-            <div className="flex h-screen">
-              <Sidebar />
-              <main className="ml-64 flex-1 overflow-auto">{children}</main>
-            </div>
+            <Layout>{children}</Layout>
             <Toaster richColors position="top-right" />
           </ThemeProvider>
         </TRPCReactProvider>

--- a/apps/admin/src/components/layout.tsx
+++ b/apps/admin/src/components/layout.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState } from 'react';
+import { Menu } from 'lucide-react';
+import { Button } from './ui/button';
+import { Sidebar } from './sidebar';
+
+export function Layout({ children }: { children: React.ReactNode }) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  return (
+    <div className="flex h-screen">
+      {/* Toggle Button */}
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => setSidebarOpen(!sidebarOpen)}
+        className="fixed top-4 left-4 z-50 md:top-4 md:left-4"
+      >
+        <Menu className="h-4 w-4" />
+        <span className="sr-only">Toggle sidebar</span>
+      </Button>
+
+      {/* Sidebar */}
+      <Sidebar isOpen={sidebarOpen} />
+      
+      {/* Main Content */}
+      <main 
+        className={`flex-1 overflow-auto transition-all duration-300 ${
+          sidebarOpen ? 'ml-64' : 'ml-0'
+        }`}
+      >
+        <div className="pt-16 px-4">
+          {children}
+        </div>
+      </main>
+
+      {/* Overlay for mobile */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-20 bg-black/50 lg:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/components/sidebar.tsx
+++ b/apps/admin/src/components/sidebar.tsx
@@ -23,11 +23,13 @@ const navigationItems = [
   },
 ];
 
-export function Sidebar() {
+export function Sidebar({ isOpen }: { isOpen: boolean }) {
   const pathname = usePathname();
 
   return (
-    <aside className="fixed inset-y-0 left-0 z-10 flex h-full w-64 flex-col border-r bg-card">
+    <aside className={`fixed inset-y-0 left-0 z-30 flex h-full w-64 flex-col border-r bg-card transition-transform duration-300 ${
+      isOpen ? 'translate-x-0' : '-translate-x-full'
+    }`}>
       <div className="flex h-14 items-center border-b px-4">
         <Link href="/" className="flex items-center gap-2 font-semibold">
           <div className="flex h-6 w-6 items-center justify-center rounded-md bg-primary text-primary-foreground">

--- a/apps/incentives/src/app/dashboard/earn/components/ActivityCard.tsx
+++ b/apps/incentives/src/app/dashboard/earn/components/ActivityCard.tsx
@@ -25,42 +25,19 @@ import {
   CardTitle,
 } from '~/components/ui/card';
 import type { IconName } from '../utils/getActivityIcon';
+import type { Activity, ActivityCategory, Dapp } from 'api/incentives';
 
-export interface RadixActivity {
-  id: string;
-  title: string;
-  description: string;
-  category: 'passive' | 'active';
-  type: 'holding' | 'trading' | 'liquidity' | 'lending' | 'network';
-  icon: IconName;
-  requirements?: string[];
-  benefits: string[];
-}
-
-type ActivityData = {
-  id: string;
-  name: string | null;
-  description: string | null;
-  category: string;
-  activityCategories: {
-    id: string;
-    name: string;
-    description: string | null;
-  };
-  dApp?: {
-    website: string;
-    name: string;
-  };
-  ap?: boolean;
-  multiplier?: boolean;
-  hide?: boolean;
-};
-
-interface ActivityCardProps {
-  activity: ActivityData;
-}
-
-export const ActivityCard = ({ activity }: ActivityCardProps) => {
+export const ActivityCard = ({
+  activity,
+  dappMap,
+  activityCategoryMap,
+}: {
+  activity: Activity;
+  dappMap: Record<string, Dapp>;
+  activityCategoryMap: Record<string, ActivityCategory>;
+}) => {
+  const dapp = dappMap[activity.dapp];
+  const activityCategory = activityCategoryMap[activity.category];
   const getCategoryIcon = (category: string) => {
     switch (category) {
       case 'lendingStables':
@@ -131,19 +108,19 @@ export const ActivityCard = ({ activity }: ActivityCardProps) => {
               </CardTitle>
             </div>
           </div>
-          {activity.dApp?.name && (
+          {dapp && (
             <Badge variant="outline" className="text-xs">
-              {activity.dApp.name}
+              {dapp.name}
             </Badge>
           )}
         </div>
         <div className="flex gap-1 mt-2">
-          {activity.ap && (
+          {activity?.data?.ap && (
             <Badge variant="secondary" className="text-xs">
               AP
             </Badge>
           )}
-          {activity.multiplier && (
+          {activity?.data?.multiplier && (
             <Badge variant="default" className="text-xs">
               Multiplier
             </Badge>
@@ -161,27 +138,16 @@ export const ActivityCard = ({ activity }: ActivityCardProps) => {
             Category:
           </h4>
           <p className="text-xs text-muted-foreground">
-            {activity.activityCategories.name}
+            {activityCategory?.name}
           </p>
         </div>
-
-        {activity.activityCategories.description && (
-          <div>
-            <h4 className="text-sm font-medium text-foreground mb-2">
-              Details:
-            </h4>
-            <p className="text-xs text-muted-foreground">
-              {activity.activityCategories.description}
-            </p>
-          </div>
-        )}
       </CardContent>
 
-      {activity.dApp?.website && (
+      {dapp && (
         <CardFooter className="pt-3">
           <Button variant="outline" size="sm" className="w-full" asChild>
             <a
-              href={activity.dApp.website}
+              href={dapp.website}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2"

--- a/apps/incentives/src/app/dashboard/earn/components/ActivityGrid.tsx
+++ b/apps/incentives/src/app/dashboard/earn/components/ActivityGrid.tsx
@@ -1,33 +1,40 @@
+import type { Activity, ActivityCategory, Dapp } from 'api/incentives';
 import { ActivityCard } from './ActivityCard';
 
-type ActivityData = {
-  id: string;
-  name: string | null;
-  description: string | null;
-  category: string;
-  activityCategories: {
-    id: string;
-    name: string;
-    description: string | null;
-  };
-  dApp?: {
-    website: string;
-    name: string;
-  };
-  ap?: boolean;
-  multiplier?: boolean;
-  hide?: boolean;
-};
+export const ActivityGrid = ({
+  activities,
+  dapps,
+  activityCategories,
+}: {
+  activities: Activity[];
+  dapps: Dapp[];
+  activityCategories: ActivityCategory[];
+}) => {
+  const dappMap = dapps.reduce(
+    (acc, dapp) => {
+      acc[dapp.id] = dapp;
+      return acc;
+    },
+    {} as Record<string, Dapp>,
+  );
 
-interface ActivityGridProps {
-  activities: ActivityData[];
-}
+  const activityCategoryMap = activityCategories.reduce(
+    (acc, category) => {
+      acc[category.id] = category;
+      return acc;
+    },
+    {} as Record<string, ActivityCategory>,
+  );
 
-export const ActivityGrid = ({ activities }: ActivityGridProps) => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       {activities.map((activity) => (
-        <ActivityCard key={activity.id} activity={activity} />
+        <ActivityCard
+          key={activity.id}
+          activity={activity}
+          dappMap={dappMap}
+          activityCategoryMap={activityCategoryMap}
+        />
       ))}
     </div>
   );

--- a/apps/incentives/src/app/dashboard/earn/components/index.ts
+++ b/apps/incentives/src/app/dashboard/earn/components/index.ts
@@ -1,4 +1,4 @@
-export { ActivityCard, type RadixActivity } from "./ActivityCard";
+export { ActivityCard } from "./ActivityCard";
 export { ActivityCardSkeleton } from "./ActivityCardSkeleton";
 export { ActivityFilters } from "./ActivityFilters";
 export { ActivityGrid } from "./ActivityGrid";

--- a/apps/incentives/src/app/dashboard/earn/page.tsx
+++ b/apps/incentives/src/app/dashboard/earn/page.tsx
@@ -12,6 +12,11 @@ export default function EarnPage() {
   const { data: activityData, isLoading } =
     api.activity.getActivityData.useQuery();
 
+  const { data: activityCategories } =
+    api.activity.getActivityCategories.useQuery();
+
+  const { data: dapps } = api.dapps.getDapps.useQuery();
+
   const [selectedCategory, setSelectedCategory] = useState<
     'all' | 'passive' | 'active'
   >('all');
@@ -22,6 +27,10 @@ export default function EarnPage() {
   const activities = activityData?.list || [];
 
   const filteredActivities = activities.filter((activity) => {
+    if (activity.data?.showOnEarnPage === false) {
+      return false;
+    }
+
     const categoryMatch =
       selectedCategory === 'all' ||
       (selectedCategory === 'passive' &&
@@ -91,7 +100,11 @@ export default function EarnPage() {
           <ActivityCardSkeleton key="skeleton-6" />
         </div>
       ) : (
-        <ActivityGrid activities={filteredActivities} />
+        <ActivityGrid
+          activities={filteredActivities}
+          dapps={dapps ?? []}
+          activityCategories={activityCategories ?? []}
+        />
       )}
     </div>
   );

--- a/packages/api/src/incentives/activity-category/activityCategory.ts
+++ b/packages/api/src/incentives/activity-category/activityCategory.ts
@@ -1,5 +1,14 @@
 import { Effect } from "effect";
 import { DbClientService, DbError } from "../db/dbClient";
+import { z } from "zod";
+
+export const ActivityCategorySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+});
+
+export type ActivityCategory = z.infer<typeof ActivityCategorySchema>;
 
 export class ActivityCategoryService extends Effect.Service<ActivityCategoryService>()(
   "ActivityCategoryService",
@@ -12,7 +21,7 @@ export class ActivityCategoryService extends Effect.Service<ActivityCategoryServ
             try: () => db.query.activityCategories.findMany(),
             catch: (error) => new DbError(error),
           });
-          return activityCategories;
+          return activityCategories as ActivityCategory[];
         }),
       };
     }),

--- a/packages/api/src/incentives/activity/activityRouter.ts
+++ b/packages/api/src/incentives/activity/activityRouter.ts
@@ -86,6 +86,22 @@ export const adminActivityRouter = createTRPCRouter({
 });
 
 export const activityRouter = createTRPCRouter({
+  getActivityCategories: publicProcedure.query(async ({ ctx }) => {
+    const result = await ctx.dependencyLayer.getActivityCategories();
+
+    return Exit.match(result, {
+      onSuccess: (value) => {
+        return value;
+      },
+      onFailure: (error) => {
+        console.error(error);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "An unexpected error occurred",
+        });
+      },
+    });
+  }),
   getActivityData: publicProcedure.query(async ({ ctx }) => {
     const result = await ctx.dependencyLayer.getActivityData();
 

--- a/packages/api/src/incentives/activity/getActivityById.ts
+++ b/packages/api/src/incentives/activity/getActivityById.ts
@@ -5,11 +5,11 @@ import {
   activities,
   activityWeeks,
   type Week,
-  type Activity,
   type ActivityWeek,
 } from "db/incentives";
 import { eq } from "drizzle-orm";
 import type { ActivityId } from "data";
+import type { Activity } from "./activity";
 
 export class NotFoundError {
   readonly _tag = "NotFoundError";

--- a/packages/api/src/incentives/dapp/dapp.ts
+++ b/packages/api/src/incentives/dapp/dapp.ts
@@ -1,5 +1,14 @@
 import { Effect } from "effect";
 import { DbClientService, DbError } from "../db/dbClient";
+import { z } from "zod";
+
+export const DappSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  website: z.string(),
+});
+
+export type Dapp = z.infer<typeof DappSchema>;
 
 export class DappService extends Effect.Service<DappService>()("DappService", {
   effect: Effect.gen(function* () {

--- a/packages/api/src/incentives/dapp/dappRouter.ts
+++ b/packages/api/src/incentives/dapp/dappRouter.ts
@@ -20,3 +20,21 @@ export const adminDappRouter = createTRPCRouter({
     });
   }),
 });
+export const dappRouter = createTRPCRouter({
+  getDapps: publicProcedure.query(async ({ ctx }) => {
+    const result = await ctx.dependencyLayer.getDapps();
+
+    return Exit.match(result, {
+      onSuccess: (value) => {
+        return value;
+      },
+      onFailure: (error) => {
+        console.error(error);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "An unexpected error occurred",
+        });
+      },
+    });
+  }),
+});

--- a/packages/api/src/incentives/index.ts
+++ b/packages/api/src/incentives/index.ts
@@ -15,5 +15,7 @@ export { UserActivityPointsService } from "./user/userActivityPoints";
 export { GetSeasonPointMultiplierService } from "./season-point-multiplier/getSeasonPointMultiplier";
 export { AddSeasonPointsToUserService } from "./season-points/addSeasonPointsToUser";
 export { UpdateWeekStatusService } from "./week/updateWeekStatus";
-export type { UpdateActivityInput } from "./activity/activity";
+export type { UpdateActivityInput, Activity } from "./activity/activity";
 export { SnapshotService, SnapshotLive } from "./snapshot/snapshot";
+export type { Dapp } from "./dapp/dapp";
+export type { ActivityCategory } from "./activity-category/activityCategory";

--- a/packages/api/src/incentives/trpc/appRouter.ts
+++ b/packages/api/src/incentives/trpc/appRouter.ts
@@ -10,7 +10,7 @@ import { adminUserRouter, userRouter } from "../user/userRouter";
 import { leaderboardRouter } from "../leaderboard/leaderboardRouter";
 import { configRouter } from "../config/configRouter";
 import { weekRouter } from "../week/weekRouter";
-import { adminDappRouter } from "../dapp/dappRouter";
+import { adminDappRouter, dappRouter } from "../dapp/dappRouter";
 
 /**
  * This is the primary router for your server.
@@ -25,6 +25,7 @@ export const appRouter = createTRPCRouter({
   activity: activityRouter,
   config: configRouter,
   week: weekRouter,
+  dapps: dappRouter,
 });
 
 export const adminAppRouter = createTRPCRouter({


### PR DESCRIPTION
## Summary
- Add "Show on earn page", Activity Points (AP), and Season Points (SP) toggle switches to activity edit form
- Make category, dapp, and component addresses read-only in edit form for data integrity
- Add new columns (component addresses, show on earn page, AP, SP) to activities table with sorting
- Implement collapsible sidebar that is hidden by default with hamburger menu toggle
- Add proper data reload after activity updates using tRPC query invalidation

## Key Features
- **Activity Edit Form**: Toggle switches for show on earn page (default: true), AP (default: false), SP (default: false)
- **Read-only Fields**: Category, dapp, and component addresses cannot be edited for data consistency
- **Enhanced Activities Table**: New sortable columns showing component addresses and feature flags
- **Collapsible Sidebar**: Space-saving UI with smooth animations and mobile overlay
- **Data Consistency**: Proper loading states and automatic data refresh after updates

## API Changes
- Updated `ActivityDataSchema` to include `showOnEarnPage`, `ap`, and `multiplier` boolean fields
- Enhanced `UpdateActivitySchema` to support component addresses and data object updates
- Modified activity service to handle new data structure properly

## Test plan
- [ ] Verify activity edit form displays all fields correctly (read-only and editable)
- [ ] Test toggle switches save properly and reflect in activities table
- [ ] Confirm sidebar can be toggled and stays hidden by default
- [ ] Check data refreshes after successful activity updates
- [ ] Validate table sorting works for all new columns
- [ ] Test responsive behavior on mobile devices

🤖 Generated with [Claude Code](https://claude.ai/code)