### PR TITLE
refactor: optimize NFT balance fetching with configurable concurrency

### DIFF
--- a/packages/api/src/common/gateway/gatewayApiClient.ts
+++ b/packages/api/src/common/gateway/gatewayApiClient.ts
@@ -19,6 +19,10 @@ export class GatewayApiClientService extends Effect.Service<GatewayApiClientServ
         Config.withDefault(undefined)
       );
 
+      const gatewayRetryAttempts = yield* Config.number(
+        "GATEWAY_RETRY_ATTEMPTS"
+      ).pipe(Config.withDefault(5));
+
       /**
        * Enable retries for ALL requests including POST
        * - Retry on network errors and 4xx/5xx status codes
@@ -27,19 +31,19 @@ export class GatewayApiClientService extends Effect.Service<GatewayApiClientServ
        */
 
       const fetchImpl = fetchRetry(globalThis.fetch, {
-        retries: 5,
+        retries: gatewayRetryAttempts,
         retryDelay: (attempt, error, response) => {
-          const baseDelay = 2 ** attempt * 1000; // 1000, 2000, 4000ms
-          const jitter = Math.random() * 0.5 * baseDelay; // Add up to 50% jitter
-          return Math.floor(baseDelay + jitter);
+          const maxDelay = 30_000; // 30 seconds max
+          const baseDelay = Math.min(2 ** attempt * 1000, maxDelay); // 1000, 2000, 4000ms etc up to max
+          return Math.floor(baseDelay);
         },
         retryOn: (attempt, error, response) => {
           // Retry on network errors
           if (error !== null) {
-            return true;
+            return false;
           }
           // Retry on 4xx/5xx status codes (including for POST requests)
-          if (response && response.status >= 400) {
+          if (response && response.status > 400) {
             return true;
           }
 

--- a/packages/api/src/common/gateway/getNftResourceManagers.ts
+++ b/packages/api/src/common/gateway/getNftResourceManagers.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Config, Effect } from "effect";
 import { GatewayApiClientService } from "./gatewayApiClient";
 import { GatewayError } from "./errors";
 import type {
@@ -28,6 +28,24 @@ export class GetNftResourceManagersService extends Effect.Service<GetNftResource
         yield* EntityNonFungiblesPageService;
       const getNonFungibleIdsService = yield* GetNonFungibleIdsService;
 
+      const getNftResourceManagersConcurrency = yield* Config.number(
+        "GET_NFT_RESOURCE_MANAGERS_CONCURRENCY"
+      ).pipe(Config.withDefault(10));
+
+      const stateEntityDetailsChunkSize = yield* Config.number(
+        "GATEWAY_STATE_ENTITY_DETAILS_CHUNK_SIZE"
+      ).pipe(Config.withDefault(20));
+
+      const stateEntityDetailsConcurrency = yield* Config.number(
+        "GATEWAY_STATE_ENTITY_DETAILS_CONCURRENCY"
+      ).pipe(Config.withDefault(20));
+
+      const getNftIdsConcurrency = yield* Config.number(
+        "GET_NFT_IDS_CONCURRENCY"
+      ).pipe(Config.withDefault(20));
+
+      const AGGREGATION_LEVEL = "Vault";
+
       const getNonFungibleResourceVaultPage = ({
         address,
         cursor,
@@ -55,7 +73,7 @@ export class GetNftResourceManagersService extends Effect.Service<GetNftResource
           catch: (error) => new GatewayError({ error }),
         }).pipe(Effect.withSpan("entityNonFungibleResourceVaultPage"));
 
-      const getNftIds = Effect.fn("getNftIds")(function* ({
+      const getNftIds = Effect.fn(function* ({
         resourceManager,
         optIns,
         at_ledger_state,
@@ -110,109 +128,122 @@ export class GetNftResourceManagersService extends Effect.Service<GetNftResource
         };
       });
 
-      const getStateEntityDetails = (
-        addresses: string[],
-        optIns: StateEntityDetailsOperationRequest["stateEntityDetailsRequest"]["opt_ins"],
-        at_ledger_state: AtLedgerState,
-        aggregationLevel: StateEntityDetailsOperationRequest["stateEntityDetailsRequest"]["aggregation_level"]
-      ) =>
-        Effect.tryPromise({
-          try: () =>
-            gatewayClient.state.innerClient.stateEntityDetails({
-              stateEntityDetailsRequest: {
-                addresses: addresses,
-                opt_ins: optIns,
-                at_ledger_state,
-                aggregation_level: aggregationLevel,
-              },
+      const getStateEntityDetails = Effect.fn("getStateEntityDetails")(
+        function* (input: {
+          addresses: string[];
+          optIns: StateEntityDetailsOperationRequest["stateEntityDetailsRequest"]["opt_ins"];
+          at_ledger_state: AtLedgerState;
+        }) {
+          const { addresses, optIns, at_ledger_state } = input;
+          const addressChunks = chunker(addresses, stateEntityDetailsChunkSize);
+
+          const results = yield* Effect.forEach(
+            addressChunks,
+            Effect.fn(function* (addresses) {
+              return yield* Effect.tryPromise({
+                try: () =>
+                  gatewayClient.state.innerClient.stateEntityDetails({
+                    stateEntityDetailsRequest: {
+                      addresses: addresses,
+                      opt_ins: optIns,
+                      at_ledger_state,
+                      aggregation_level: AGGREGATION_LEVEL,
+                    },
+                  }),
+                catch: (error) => new GatewayError({ error }),
+              });
             }),
-          catch: (error) => new GatewayError({ error }),
-        }).pipe(Effect.withSpan("getStateEntityDetails"));
+            { concurrency: stateEntityDetailsConcurrency }
+          );
+
+          return results;
+        }
+      );
+
+      const getResourceManagers = Effect.fn(function* (input: {
+        items: StateEntityDetailsResponseItem[];
+        at_ledger_state: AtLedgerState;
+        aggregationLevel: StateEntityDetailsOperationRequest["stateEntityDetailsRequest"]["aggregation_level"];
+        optIns: StateEntityDetailsOperationRequest["stateEntityDetailsRequest"]["opt_ins"];
+        filterResourceAddresses?: string[];
+      }) {
+        const { items, aggregationLevel, optIns, filterResourceAddresses } =
+          input;
+        return yield* Effect.forEach(
+          items,
+          Effect.fn(function* (item) {
+            const resourceManagers =
+              (item.non_fungible_resources
+                ?.items as NonFungibleResourcesCollectionItemVaultAggregated[]) ??
+              [];
+
+            const address = item.address;
+
+            let next_cursor = item.non_fungible_resources?.next_cursor;
+            const totalCount = item.non_fungible_resources?.total_count ?? 0;
+
+            while (next_cursor && totalCount > 0) {
+              const entityNonFungiblesPageResult =
+                yield* entityNonFungiblesPageService({
+                  address,
+                  at_ledger_state: input.at_ledger_state,
+                  aggregation_level: aggregationLevel,
+                  opt_ins: optIns,
+                  cursor: next_cursor,
+                });
+
+              resourceManagers.push(
+                ...(entityNonFungiblesPageResult.items as NonFungibleResourcesCollectionItemVaultAggregated[])
+              );
+
+              next_cursor = entityNonFungiblesPageResult.next_cursor;
+            }
+
+            const filteredResourceManagers = filterResourceAddresses
+              ? resourceManagers.filter((resourceManager) =>
+                  filterResourceAddresses.includes(
+                    resourceManager.resource_address
+                  )
+                )
+              : resourceManagers;
+
+            return {
+              address,
+              resourceManagers: filteredResourceManagers,
+            };
+          })
+        );
+      });
 
       return Effect.fn("getNftResourceManagersService")(function* (
-        input: GetNftResourceManagersInput,
-        options?: {
-          chunkSize?: number;
-          concurrency?: number;
-        }
+        input: GetNftResourceManagersInput
       ) {
-        yield* Effect.logTrace(input);
-        const aggregationLevel = "Vault";
-
         const optIns = { ...input.options, non_fungible_include_nfids: true };
-
-        const chunkSize = options?.chunkSize ?? 20;
-        const concurrency = options?.concurrency ?? 10;
 
         const filterResourceAddresses = input.resourceAddresses;
 
-        const getResourceManagers = (items: StateEntityDetailsResponseItem[]) =>
-          Effect.forEach(items, (item) =>
-            Effect.gen(function* () {
-              const resourceManagers =
-                (item.non_fungible_resources
-                  ?.items as NonFungibleResourcesCollectionItemVaultAggregated[]) ??
-                [];
-
-              const address = item.address;
-
-              let next_cursor = item.non_fungible_resources?.next_cursor;
-              const totalCount = item.non_fungible_resources?.total_count ?? 0;
-
-              while (next_cursor && totalCount > 0) {
-                const entityNonFungiblesPageResult =
-                  yield* entityNonFungiblesPageService({
-                    address,
-                    at_ledger_state: input.at_ledger_state,
-                    aggregation_level: aggregationLevel,
-                    opt_ins: optIns,
-                    cursor: next_cursor,
-                  }).pipe(Effect.withSpan("entityNonFungiblesPageService"));
-
-                resourceManagers.push(
-                  ...(entityNonFungiblesPageResult.items as NonFungibleResourcesCollectionItemVaultAggregated[])
-                );
-
-                next_cursor = entityNonFungiblesPageResult.next_cursor;
-              }
-
-              const filteredResourceManagers = filterResourceAddresses
-                ? resourceManagers.filter((resourceManager) =>
-                    filterResourceAddresses.includes(
-                      resourceManager.resource_address
-                    )
-                  )
-                : resourceManagers;
-
-              return {
-                address,
-                resourceManagers: filteredResourceManagers,
-              };
-            })
-          );
-
-        const addressChunks = chunker(input.addresses, chunkSize);
-
-        const stateEntityDetailsResults = yield* Effect.forEach(
-          addressChunks,
-          Effect.fn(function* (addresses) {
-            return yield* getStateEntityDetails(
-              addresses,
-              optIns,
-              input.at_ledger_state,
-              aggregationLevel
-            );
-          }),
-          { concurrency }
-        ).pipe(Effect.map((items) => items.flat()));
+        const stateEntityDetailsResults = yield* getStateEntityDetails({
+          addresses: input.addresses,
+          optIns,
+          at_ledger_state: input.at_ledger_state,
+        });
 
         const resourceManagerResults = yield* Effect.forEach(
           stateEntityDetailsResults,
           Effect.fn(function* (stateEntityDetails) {
-            return yield* getResourceManagers(stateEntityDetails.items);
+            return yield* getResourceManagers({
+              items: stateEntityDetails.items,
+              at_ledger_state: input.at_ledger_state,
+              aggregationLevel: AGGREGATION_LEVEL,
+              optIns,
+              filterResourceAddresses,
+            });
           }),
-          { concurrency }
-        ).pipe(Effect.map((items) => items.flat()));
+          { concurrency: getNftResourceManagersConcurrency }
+        ).pipe(
+          Effect.map((items) => items.flat()),
+          Effect.withSpan("getResourceManagers")
+        );
 
         const results = yield* Effect.forEach(
           resourceManagerResults,
@@ -233,8 +264,8 @@ export class GetNftResourceManagersService extends Effect.Service<GetNftResource
               items: nftIds,
             };
           }),
-          { concurrency }
-        );
+          { concurrency: getNftIdsConcurrency }
+        ).pipe(Effect.withSpan("getNftIds"));
 
         return results;
       });

--- a/packages/api/src/common/gateway/getNonFungibleBalance.ts
+++ b/packages/api/src/common/gateway/getNonFungibleBalance.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Config, Effect } from "effect";
 
 import type { StateEntityDetailsOperationRequest } from "@radixdlt/babylon-gateway-api-sdk";
 import { EntityNonFungibleDataService } from "./entityNonFungiblesData";
@@ -16,8 +16,6 @@ type GetNonFungibleBalanceInput = {
   at_ledger_state: AtLedgerState;
   resourceAddresses?: string[];
   options?: StateEntityDetailsOperationRequest["stateEntityDetailsRequest"]["opt_ins"];
-  chunkSize?: number;
-  concurrency?: number;
 };
 
 export type GetNonFungibleBalanceOutput = Effect.Effect.Success<
@@ -32,70 +30,81 @@ export class GetNonFungibleBalanceService extends Effect.Service<GetNonFungibleB
       const getNftResourceManagersService =
         yield* GetNftResourceManagersService;
 
+      const getNonFungibleDataConcurrency = yield* Config.number(
+        "GATEWAY_GET_NON_FUNGIBLE_DATA_CONCURRENCY"
+      ).pipe(Config.withDefault(20));
+
+      const getNonFungibleData = Effect.fn(function* (input: {
+        items: {
+          resourceAddress: string;
+          nftIds: string[];
+        }[];
+
+        at_ledger_state: AtLedgerState;
+      }) {
+        return yield* Effect.forEach(
+          input.items,
+          Effect.fn(function* (item) {
+            if (item.nftIds.length === 0) {
+              return yield* Effect.succeed({
+                resourceAddress: item.resourceAddress,
+                items: [],
+              });
+            }
+
+            const result = yield* entityNonFungibleDataService({
+              resource_address: item.resourceAddress,
+              non_fungible_ids: item.nftIds,
+              at_ledger_state: input.at_ledger_state,
+            });
+
+            const items = result.map((nftDataItem) => ({
+              id: nftDataItem.non_fungible_id,
+              lastUpdatedStateVersion:
+                nftDataItem.last_updated_at_state_version,
+              sbor: nftDataItem.data?.programmatic_json,
+              isBurned: nftDataItem.is_burned,
+            }));
+
+            return {
+              resourceAddress: item.resourceAddress,
+              items,
+            };
+          })
+        );
+      });
+
       return Effect.fn("getNonFungibleBalanceService")(function* (
         input: GetNonFungibleBalanceInput
       ) {
-        const concurrency = input.concurrency ?? 10;
-        const chunkSize = input.chunkSize ?? 20;
-
         const optIns = { ...input.options, non_fungible_include_nfids: true };
 
-        const resourceManagersResults = yield* getNftResourceManagersService(
+        // Get non-fungible ids for each account
+        const accountNonFungibleBalances = yield* getNftResourceManagersService(
           {
             addresses: input.addresses,
             at_ledger_state: input.at_ledger_state,
             resourceAddresses: input.resourceAddresses,
             options: optIns,
-          },
-          {
-            chunkSize,
-            concurrency,
           }
         );
 
+        // Get non-fungible data for each account
         const result = yield* Effect.forEach(
-          resourceManagersResults,
-          Effect.fn(function* (resourceManagerResult) {
-            const nonFungibleResources = yield* Effect.forEach(
-              resourceManagerResult.items,
-              Effect.fn(function* (resourceManager) {
-                if (resourceManager.nftIds.length === 0) {
-                  return yield* Effect.succeed({
-                    resourceAddress: resourceManager.resourceAddress,
-                    items: [],
-                  });
-                }
-                return yield* entityNonFungibleDataService({
-                  resource_address: resourceManager.resourceAddress,
-                  non_fungible_ids: resourceManager.nftIds,
-                  at_ledger_state: input.at_ledger_state,
-                }).pipe(
-                  Effect.withSpan("entityNonFungibleDataService"),
-                  Effect.map((nftDataResult) => {
-                    const items = nftDataResult.map((nftDataItem) => ({
-                      id: nftDataItem.non_fungible_id,
-                      lastUpdatedStateVersion:
-                        nftDataItem.last_updated_at_state_version,
-                      sbor: nftDataItem.data?.programmatic_json,
-                      isBurned: nftDataItem.is_burned,
-                    }));
-
-                    return {
-                      resourceAddress: resourceManager.resourceAddress,
-                      items,
-                    };
-                  })
-                );
-              })
-            );
+          accountNonFungibleBalances,
+          Effect.fn(function* ({ address, items }) {
+            const nonFungibleResourcesWithNftData = yield* getNonFungibleData({
+              items,
+              at_ledger_state: input.at_ledger_state,
+            });
 
             return {
-              address: resourceManagerResult.address,
-              nonFungibleResources,
+              address,
+              nonFungibleResources: nonFungibleResourcesWithNftData,
             };
           }),
-          { concurrency }
-        );
+          { concurrency: getNonFungibleDataConcurrency }
+        ).pipe(Effect.withSpan("get non-fungible data for each account"));
 
         return { items: result };
       });

--- a/tools/calculate-points/package.json
+++ b/tools/calculate-points/package.json
@@ -6,7 +6,9 @@
     "calc:sp": "tsx --watch src/calculateSeasonPoints.ts",
     "calc:ap": "tsx --watch src/calculateActivityPoints.ts",
     "snapshot": "tsx --watch src/snapshot.ts",
-    "snapshot:inspect": "tsx --inspect-brk src/snapshot.ts"
+    "snapshot:inspect": "tsx --inspect-brk src/snapshot.ts",
+    "nft-balance": "tsx --watch src/getNonFungibleBalance.ts",
+    "nft-balance:inspect": "tsx --inspect-brk src/getNonFungibleBalance.ts"
   },
   "devDependencies": {
     "tsup": "catalog:",

--- a/tools/calculate-points/src/getNonFungibleBalance.ts
+++ b/tools/calculate-points/src/getNonFungibleBalance.ts
@@ -1,0 +1,138 @@
+import { Effect, Exit, Layer, Logger } from "effect";
+import { db } from "db/incentives";
+import { NodeSdk } from "@effect/opentelemetry";
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+
+export const NodeSdkLive = NodeSdk.layer(() => ({
+  resource: { serviceName: "nonFungibleBalance" },
+  spanProcessor: new BatchSpanProcessor(
+    new OTLPTraceExporter({
+      url: "http://127.0.0.1:4318/v1/traces",
+    })
+  ),
+}));
+
+// Gateway services
+import { GatewayApiClientLive } from "../../../packages/api/src/common/gateway/gatewayApiClient";
+import { EntityNonFungiblesPageService } from "../../../packages/api/src/common/gateway/entityNonFungiblesPage";
+import { EntityNonFungibleDataService } from "../../../packages/api/src/common/gateway/entityNonFungiblesData";
+import { GetNonFungibleBalanceService } from "../../../packages/api/src/common/gateway/getNonFungibleBalance";
+import { GetNftResourceManagersService } from "../../../packages/api/src/common/gateway/getNftResourceManagers";
+import { GetNonFungibleIdsService } from "../../../packages/api/src/common/gateway/getNonFungibleIds";
+import {
+  CaviarNineConstants,
+  OciswapConstants,
+  RootFinanceConstants,
+  WeftFinanceConstants,
+} from "../../../packages/data/src";
+import { GetAllValidatorsService } from "../../../packages/api/src/common/gateway/getAllValidators";
+import { GetLedgerStateService } from "../../../packages/api/src/common/gateway/getLedgerState";
+
+const runnable = Effect.gen(function* () {
+  const gatewayApiClientLive = GatewayApiClientLive;
+
+  const entityNonFungiblesPageServiceLive =
+    EntityNonFungiblesPageService.Default.pipe(
+      Layer.provide(gatewayApiClientLive)
+    );
+
+  const entityNonFungibleDataServiceLive =
+    EntityNonFungibleDataService.Default.pipe(
+      Layer.provide(gatewayApiClientLive)
+    );
+
+  const getNonFungibleIdsLive = GetNonFungibleIdsService.Default.pipe(
+    Layer.provide(gatewayApiClientLive)
+  );
+
+  const getNftResourceManagersLive = GetNftResourceManagersService.Default.pipe(
+    Layer.provide(gatewayApiClientLive),
+    Layer.provide(entityNonFungiblesPageServiceLive),
+    Layer.provide(getNonFungibleIdsLive)
+  );
+
+  const getNonFungibleBalanceLive = GetNonFungibleBalanceService.Default.pipe(
+    Layer.provide(entityNonFungibleDataServiceLive),
+    Layer.provide(getNftResourceManagersLive)
+  );
+
+  const getAllValidatorsServiceLive = GetAllValidatorsService.Default.pipe(
+    Layer.provide(gatewayApiClientLive)
+  );
+
+  const getLedgerStateServiceLive = GetLedgerStateService.Default.pipe(
+    Layer.provide(gatewayApiClientLive)
+  );
+
+  const getLedgerStateService = yield* Effect.provide(
+    GetLedgerStateService,
+    getLedgerStateServiceLive
+  );
+
+  const at_ledger_state = yield* getLedgerStateService({
+    at_ledger_state: { timestamp: new Date("2025-07-20T00:00:00.000Z") },
+  });
+
+  const getAllValidators = yield* Effect.provide(
+    GetAllValidatorsService,
+    getAllValidatorsServiceLive
+  );
+
+  const validators = yield* getAllValidators();
+
+  const service = yield* Effect.provide(
+    GetNonFungibleBalanceService,
+    getNonFungibleBalanceLive
+  );
+
+  const addresses = yield* Effect.tryPromise(() =>
+    db.query.accounts
+      .findMany({
+        // limit: 1,
+      })
+      .then((res) => res.map((r) => r.address))
+  );
+
+  const resourceAddresses = [
+    ...Object.values(CaviarNineConstants.shapeLiquidityPools).map(
+      (pool) => pool.liquidity_receipt
+    ),
+    ...Object.values(OciswapConstants.pools).map(
+      (pool) => pool.lpResourceAddress
+    ),
+    ...Object.values(OciswapConstants.poolsV2).map(
+      (pool) => pool.lpResourceAddress
+    ),
+    RootFinanceConstants.receiptResourceAddress,
+    WeftFinanceConstants.v2.WeftyV2.resourceAddress,
+    ...validators.map((validator) => validator.claimNftResourceAddress),
+  ];
+
+  yield* Effect.log(
+    `getting non fungible balance for ${addresses.length} addresses and ${resourceAddresses.length} resource addresses at state version: ${at_ledger_state.state_version}`
+  );
+
+  yield* service({
+    addresses,
+    at_ledger_state: {
+      state_version: at_ledger_state.state_version,
+    },
+    resourceAddresses,
+  }).pipe(Effect.provide(NodeSdkLive));
+
+  yield* Effect.log("done");
+});
+
+const result = await Effect.runPromiseExit(
+  runnable.pipe(Effect.provide(Logger.pretty))
+);
+
+Exit.match(result, {
+  onFailure: (error) => {
+    console.error(JSON.stringify(error, null, 2));
+  },
+  onSuccess: (value) => {
+    console.log(value);
+  },
+});

--- a/tools/calculate-points/src/snapshot.ts
+++ b/tools/calculate-points/src/snapshot.ts
@@ -376,17 +376,15 @@ const runnable = Effect.gen(function* () {
   const addresses = yield* Effect.tryPromise(() =>
     db.query.accounts
       .findMany({
-        limit: 100,
+        // limit: 100,
       })
       .then((res) => res.map((r) => r.address))
   );
 
   yield* service({
     timestamp: new Date(),
-    batchSize: 10000,
-    addresses: [
-      "account_rdx12xl2meqtelz47mwp3nzd72jkwyallg5yxr9hkc75ac4qztsxulfpew",
-    ],
+    batchSize: 10_000,
+    // addresses: [],
   }).pipe(Effect.provide(NodeSdkLive));
 });
 


### PR DESCRIPTION
## Summary
- Optimized NFT balance fetching performance with configurable concurrency settings
- Improved gateway API client retry logic and error handling
- Added chunking and parallel processing for better scalability

## Changes
- Added environment variables for fine-tuning concurrency:
  - `GATEWAY_RETRY_ATTEMPTS` - Controls retry attempts for gateway requests
  - `GET_NFT_RESOURCE_MANAGERS_CONCURRENCY` - Controls parallel NFT resource manager fetches
  - `GATEWAY_STATE_ENTITY_DETAILS_CHUNK_SIZE` - Controls batch size for entity details
  - `GATEWAY_STATE_ENTITY_DETAILS_CONCURRENCY` - Controls parallel entity detail fetches
  - `GET_NFT_IDS_CONCURRENCY` - Controls parallel NFT ID fetches
  - `GATEWAY_GET_NON_FUNGIBLE_DATA_CONCURRENCY` - Controls parallel NFT data fetches

- Refactored gateway retry logic:
  - Exponential backoff with max delay of 30 seconds
  - Network errors no longer retry (fail fast)
  - Only retry on HTTP status > 400

- Improved code organization:
  - Split complex functions into smaller, focused Effect functions
  - Better error handling and tracing with Effect spans
  - Removed hardcoded concurrency values in favor of configurable ones

## Test plan
- [ ] Run snapshot tool with various account counts
- [ ] Test with different concurrency settings
- [ ] Verify retry logic works correctly with gateway errors
- [ ] Check performance improvements with large datasets
- [ ] Ensure backward compatibility with existing code

🤖 Generated with [Claude Code](https://claude.ai/code)