### PR TITLE
Add BigNumber deserialization utility and DefiPlaza test fixtures

### DIFF
--- a/packages/api/src/common/dapps/defiplaza/fixtures/fungibleBalance.ts
+++ b/packages/api/src/common/dapps/defiplaza/fixtures/fungibleBalance.ts
@@ -1,0 +1,553 @@
+import type { GetFungibleBalanceOutput } from "../../../gateway/getFungibleBalance";
+import BigNumber from "bignumber.js";
+import { deserializeBigNumber } from "../../../utils/deserializeBigNumber";
+
+export const fungibleBalance = [
+  {
+    address:
+      "account_rdx12x2a5dft0gszufcce98ersqvsd8qr5kzku968jd50n8w4qyl9awecr",
+    fungibleResources: [
+      {
+        resourceAddress:
+          "resource_rdx1tkdws0nvfwjnn2q62x4gqgelyt4t5z7cn58pwvrtf4zrxtdw2sem8x",
+        amount: {
+          s: 1,
+          e: 1,
+          c: [19, 23797024451522, 20310000000000],
+        },
+        lastUpdatedStateVersion: 302823029,
+      },
+      {
+        resourceAddress:
+          "resource_rdx1thdahk9aypz6c4f4uygkgl40c8nt0arc0fnxrsj4ar3tsrm4s208cx",
+        amount: {
+          s: 1,
+          e: 0,
+          c: [1],
+        },
+        lastUpdatedStateVersion: 165489810,
+      },
+      {
+        resourceAddress:
+          "resource_rdx1thyp96620fhte4qvgw5rfkl66rv9hvhfqw2vtw4u2erwv5wnu9238q",
+        amount: {
+          s: 1,
+          e: 2,
+          c: [500],
+        },
+        lastUpdatedStateVersion: 74505377,
+      },
+      {
+        resourceAddress:
+          "resource_rdx1t4h4396mukhpzdrr5sfvegjsxl8q7a34q2vkt4quxcxahna8fucuz4",
+        amount: {
+          s: 1,
+          e: 0,
+          c: [2],
+        },
+        lastUpdatedStateVersion: 52430567,
+      },
+      {
+        resourceAddress:
+          "resource_rdx1t4tjx4g3qzd98nayqxm7qdpj0a0u8ns6a0jrchq49dyfevgh6u0gj3",
+        amount: {
+          s: 1,
+          e: 0,
+          c: [9, 41275300000000],
+        },
+        lastUpdatedStateVersion: 77445290,
+      },
+      {
+        resourceAddress:
+          "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+        amount: {
+          s: 1,
+          e: 3,
+          c: [1232, 86372261163929, 69040000000000],
+        },
+        lastUpdatedStateVersion: 302823029,
+      },
+    ],
+    details: {
+      type: "Component",
+      package_address:
+        "package_rdx1pkgxxxxxxxxxaccntxxxxxxxxxx000929625493xxxxxxxxxaccntx",
+      blueprint_name: "Account",
+      blueprint_version: "1.0.0",
+      state: {
+        default_deposit_rule: "Accept",
+      },
+      role_assignments: {
+        owner: {
+          rule: {
+            type: "Protected",
+            access_rule: {
+              type: "ProofRule",
+              proof_rule: {
+                type: "Require",
+                requirement: {
+                  type: "NonFungible",
+                  non_fungible: {
+                    local_id: {
+                      id_type: "Bytes",
+                      sbor_hex:
+                        "5cc0021d95da352b7a202e2718c94f91c00c834e01d2c2b70ba3c9b47cceea809f",
+                      simple_rep:
+                        "[95da352b7a202e2718c94f91c00c834e01d2c2b70ba3c9b47cceea809f]",
+                    },
+                    resource_address:
+                      "resource_rdx1nfxxxxxxxxxxed25sgxxxxxxxxx002236757237xxxxxxxxxed25sg",
+                  },
+                },
+              },
+            },
+          },
+          updater: "Object",
+        },
+        entries: [
+          {
+            role_key: {
+              name: "securify",
+              module: "Main",
+            },
+            assignment: {
+              resolution: "Explicit",
+              explicit_rule: {
+                type: "Protected",
+                access_rule: {
+                  type: "ProofRule",
+                  proof_rule: {
+                    type: "Require",
+                    requirement: {
+                      type: "NonFungible",
+                      non_fungible: {
+                        local_id: {
+                          id_type: "Bytes",
+                          sbor_hex:
+                            "5cc0021d95da352b7a202e2718c94f91c00c834e01d2c2b70ba3c9b47cceea809f",
+                          simple_rep:
+                            "[95da352b7a202e2718c94f91c00c834e01d2c2b70ba3c9b47cceea809f]",
+                        },
+                        resource_address:
+                          "resource_rdx1nfxxxxxxxxxxed25sgxxxxxxxxx002236757237xxxxxxxxxed25sg",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            updater_roles: [
+              {
+                name: "_self_",
+                module: "Main",
+              },
+            ],
+          },
+          {
+            role_key: {
+              name: "metadata_locker",
+              module: "Metadata",
+            },
+            assignment: {
+              resolution: "Owner",
+            },
+            updater_roles: [
+              {
+                name: "metadata_locker_updater",
+                module: "Metadata",
+              },
+            ],
+          },
+          {
+            role_key: {
+              name: "metadata_locker_updater",
+              module: "Metadata",
+            },
+            assignment: {
+              resolution: "Owner",
+            },
+            updater_roles: [
+              {
+                name: "metadata_locker_updater",
+                module: "Metadata",
+              },
+            ],
+          },
+          {
+            role_key: {
+              name: "metadata_setter",
+              module: "Metadata",
+            },
+            assignment: {
+              resolution: "Owner",
+            },
+            updater_roles: [
+              {
+                name: "metadata_setter_updater",
+                module: "Metadata",
+              },
+            ],
+          },
+          {
+            role_key: {
+              name: "metadata_setter_updater",
+              module: "Metadata",
+            },
+            assignment: {
+              resolution: "Owner",
+            },
+            updater_roles: [
+              {
+                name: "metadata_setter_updater",
+                module: "Metadata",
+              },
+            ],
+          },
+        ],
+      },
+      royalty_vault_balance: undefined,
+      royalty_config: undefined,
+      two_way_linked_dapp_address: undefined,
+      direct_linked_dapp_address: undefined,
+      blueprint_linked_dapp_address: undefined,
+      two_way_linked_dapp_details: undefined,
+      native_resource_details: undefined,
+    },
+    metadata: {
+      total_count: 8,
+      next_cursor: undefined,
+      items: [
+        {
+          key: "claimed_entities",
+          value: {
+            raw_hex:
+              "5c228801208006c009e8023b3494ebdfe0f8c847d2e28175b7f65362a39f4bccecf6d73bf8c0b3ecfab1f10a1dcd762d5de5649d9cd0ea29523912ff77aaf2473d47655d08e0571a9b55f35b3bb32bc12cecf1bd0dcb08e0814823a972fb0eebfcc02355f6b08316436e2c4bff5cff3c9afdc116fda38821e0baa181d4b799c078b351771ceea2ef81d764279bcc2bd1568a6c3384e131a59a1075f00cc01aace94a202679deacaf3eab907fe72212159f20bccb89b290a05a0f29",
+            programmatic_json: {
+              kind: "Enum",
+              type_name: undefined,
+              field_name: undefined,
+              variant_id: "136",
+              variant_name: undefined,
+              fields: [
+                {
+                  kind: "Array",
+                  type_name: undefined,
+                  field_name: undefined,
+                  element_kind: "Reference",
+                  element_type_name: undefined,
+                  elements: [
+                    {
+                      kind: "Reference",
+                      type_name: undefined,
+                      field_name: undefined,
+                      value:
+                        "component_rdx1cqy7sq3mxj2whhlqlryy05hzs96m0ajnv23e7j7vanmdwwlccnmz68",
+                    },
+                    {
+                      kind: "Reference",
+                      type_name: undefined,
+                      field_name: undefined,
+                      value:
+                        "component_rdx1cze7e7437y9pmntk94w72eyanngw522j8yf07aa27frn63m9ezkfeu",
+                    },
+                    {
+                      kind: "Reference",
+                      type_name: undefined,
+                      field_name: undefined,
+                      value:
+                        "resource_rdx1t5ywq4c6nd2lxkemkv4uzt8v7x7smjcguzq5sgafwtasa6luq7fclq",
+                    },
+                    {
+                      kind: "Reference",
+                      type_name: undefined,
+                      field_name: undefined,
+                      value:
+                        "component_rdx1cq34ta4ssvtyxm3vf0l4eleunt7uz9ha5wyzrc965xqafdueadpy4x",
+                    },
+                    {
+                      kind: "Reference",
+                      type_name: undefined,
+                      field_name: undefined,
+                      value:
+                        "component_rdx1cputx5thrnh29mup6ajz0x7v90g4dznvxwzwzvd9ngg8tuqvqlxmlh",
+                    },
+                    {
+                      kind: "Reference",
+                      type_name: undefined,
+                      field_name: undefined,
+                      value:
+                        "component_rdx1cqd2e622yqn8nh4v4ul2hyrluu3py9vlyz7vhzdjjzs95refpdem7w",
+                    },
+                  ],
+                },
+              ],
+            },
+            typed: {
+              type: "GlobalAddressArray",
+              values: [
+                "component_rdx1cqy7sq3mxj2whhlqlryy05hzs96m0ajnv23e7j7vanmdwwlccnmz68",
+                "component_rdx1cze7e7437y9pmntk94w72eyanngw522j8yf07aa27frn63m9ezkfeu",
+                "resource_rdx1t5ywq4c6nd2lxkemkv4uzt8v7x7smjcguzq5sgafwtasa6luq7fclq",
+                "component_rdx1cq34ta4ssvtyxm3vf0l4eleunt7uz9ha5wyzrc965xqafdueadpy4x",
+                "component_rdx1cputx5thrnh29mup6ajz0x7v90g4dznvxwzwzvd9ngg8tuqvqlxmlh",
+                "component_rdx1cqd2e622yqn8nh4v4ul2hyrluu3py9vlyz7vhzdjjzs95refpdem7w",
+              ],
+            },
+          },
+          is_locked: false,
+          last_updated_at_state_version: 102329840,
+        },
+        {
+          key: "account_type",
+          value: {
+            raw_hex: "5c2200010c0f6461707020646566696e6974696f6e",
+            programmatic_json: {
+              kind: "Enum",
+              type_name: undefined,
+              field_name: undefined,
+              variant_id: "0",
+              variant_name: undefined,
+              fields: [
+                {
+                  kind: "String",
+                  type_name: undefined,
+                  field_name: undefined,
+                  value: "dapp definition",
+                },
+              ],
+            },
+            typed: {
+              type: "String",
+              value: "dapp definition",
+            },
+          },
+          is_locked: false,
+          last_updated_at_state_version: 506838,
+        },
+        {
+          key: "icon_url",
+          value: {
+            raw_hex:
+              "5c220d010c4168747470733a2f2f72616469782e64656669706c617a612e6e65742f6173736574732f696d672f626162796c6f6e2f64656669706c617a612d69636f6e2e706e67",
+            programmatic_json: {
+              kind: "Enum",
+              type_name: undefined,
+              field_name: undefined,
+              variant_id: "13",
+              variant_name: undefined,
+              fields: [
+                {
+                  kind: "String",
+                  type_name: undefined,
+                  field_name: undefined,
+                  value:
+                    "https://radix.defiplaza.net/assets/img/babylon/defiplaza-icon.png",
+                },
+              ],
+            },
+            typed: {
+              type: "Url",
+              value:
+                "https://radix.defiplaza.net/assets/img/babylon/defiplaza-icon.png",
+            },
+          },
+          is_locked: false,
+          last_updated_at_state_version: 296858031,
+        },
+        {
+          key: "description",
+          value: {
+            raw_hex:
+              "5c2200010c7c4120444558207370656369666963616c6c792064657369676e656420746f2072656475636520746865207269736b206f6620496d7065726d616e656e74204c6f737320616e642068656c70206d616b652070726f766964696e67206c6971756964697479207375737461696e61626c792070726f66697461626c652e",
+            programmatic_json: {
+              kind: "Enum",
+              type_name: undefined,
+              field_name: undefined,
+              variant_id: "0",
+              variant_name: undefined,
+              fields: [
+                {
+                  kind: "String",
+                  type_name: undefined,
+                  field_name: undefined,
+                  value:
+                    "A DEX specifically designed to reduce the risk of Impermanent Loss and help make providing liquidity sustainably profitable.",
+                },
+              ],
+            },
+            typed: {
+              type: "String",
+              value:
+                "A DEX specifically designed to reduce the risk of Impermanent Loss and help make providing liquidity sustainably profitable.",
+            },
+          },
+          is_locked: false,
+          last_updated_at_state_version: 296858031,
+        },
+        {
+          key: "name",
+          value: {
+            raw_hex: "5c2200010c0944656669506c617a61",
+            programmatic_json: {
+              kind: "Enum",
+              type_name: undefined,
+              field_name: undefined,
+              variant_id: "0",
+              variant_name: undefined,
+              fields: [
+                {
+                  kind: "String",
+                  type_name: undefined,
+                  field_name: undefined,
+                  value: "DefiPlaza",
+                },
+              ],
+            },
+            typed: {
+              type: "String",
+              value: "DefiPlaza",
+            },
+          },
+          is_locked: false,
+          last_updated_at_state_version: 506838,
+        },
+        {
+          key: "claimed_websites",
+          value: {
+            raw_hex:
+              "5c228e01200c021b68747470733a2f2f72616469782e64656669706c617a612e6e65741b68747470733a2f2f61646d696e2e64656669706c617a612e6e6574",
+            programmatic_json: {
+              kind: "Enum",
+              type_name: undefined,
+              field_name: undefined,
+              variant_id: "142",
+              variant_name: undefined,
+              fields: [
+                {
+                  kind: "Array",
+                  type_name: undefined,
+                  field_name: undefined,
+                  element_kind: "String",
+                  element_type_name: undefined,
+                  elements: [
+                    {
+                      kind: "String",
+                      type_name: undefined,
+                      field_name: undefined,
+                      value: "https://radix.defiplaza.net",
+                    },
+                    {
+                      kind: "String",
+                      type_name: undefined,
+                      field_name: undefined,
+                      value: "https://admin.defiplaza.net",
+                    },
+                  ],
+                },
+              ],
+            },
+            typed: {
+              type: "OriginArray",
+              values: [
+                "https://radix.defiplaza.net",
+                "https://admin.defiplaza.net",
+              ],
+            },
+          },
+          is_locked: false,
+          last_updated_at_state_version: 296858031,
+        },
+        {
+          key: "owner_keys",
+          value: {
+            raw_hex:
+              "5c228f01202201010120071d95da352b7a202e2718c94f91c00c834e01d2c2b70ba3c9b47cceea809f",
+            programmatic_json: {
+              kind: "Enum",
+              type_name: undefined,
+              field_name: undefined,
+              variant_id: "143",
+              variant_name: undefined,
+              fields: [
+                {
+                  kind: "Array",
+                  type_name: undefined,
+                  field_name: undefined,
+                  element_kind: "Enum",
+                  element_type_name: undefined,
+                  elements: [
+                    {
+                      kind: "Enum",
+                      type_name: undefined,
+                      field_name: undefined,
+                      variant_id: "1",
+                      variant_name: undefined,
+                      fields: [
+                        {
+                          kind: "Bytes",
+                          type_name: undefined,
+                          field_name: undefined,
+                          element_kind: "U8",
+                          element_type_name: undefined,
+                          hex: "95da352b7a202e2718c94f91c00c834e01d2c2b70ba3c9b47cceea809f",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            typed: {
+              type: "PublicKeyHashArray",
+              values: [
+                {
+                  key_hash_type: "EddsaEd25519",
+                  hash_hex:
+                    "95da352b7a202e2718c94f91c00c834e01d2c2b70ba3c9b47cceea809f",
+                },
+              ],
+            },
+          },
+          is_locked: false,
+          last_updated_at_state_version: 503428,
+        },
+        {
+          key: "owner_badge",
+          value: {
+            raw_hex:
+              "5c220b01c0021e5195da352b7a202e2718c94f91c00c834e01d2c2b70ba3c9b47cceea809f",
+            programmatic_json: {
+              kind: "Enum",
+              type_name: undefined,
+              field_name: undefined,
+              variant_id: "11",
+              variant_name: undefined,
+              fields: [
+                {
+                  kind: "NonFungibleLocalId",
+                  type_name: undefined,
+                  field_name: undefined,
+                  value:
+                    "[5195da352b7a202e2718c94f91c00c834e01d2c2b70ba3c9b47cceea809f]",
+                },
+              ],
+            },
+            typed: {
+              type: "NonFungibleLocalId",
+              value:
+                "[5195da352b7a202e2718c94f91c00c834e01d2c2b70ba3c9b47cceea809f]",
+            },
+          },
+          is_locked: true,
+          last_updated_at_state_version: 503428,
+        },
+      ],
+    },
+  },
+].map((item) => ({
+  ...item,
+  fungibleResources: item.fungibleResources.map((resource) => ({
+    ...resource,
+    amount: deserializeBigNumber(resource.amount),
+  })),
+})) as GetFungibleBalanceOutput;

--- a/packages/api/src/common/dapps/defiplaza/fixtures/pools.ts
+++ b/packages/api/src/common/dapps/defiplaza/fixtures/pools.ts
@@ -1,0 +1,320 @@
+import type { GetResourcePoolOutput } from "../../../resource-pool/getResourcePoolUnits";
+import BigNumber from "bignumber.js";
+import { deserializeBigNumber } from "../../../utils/deserializeBigNumber";
+
+export const pools: GetResourcePoolOutput = [
+  {
+    address: "pool_rdx1c4547fnprjhlp2m27aycmf8rzrkrfzcck58jt2706r85gpcaeapz7k",
+    lpResourceAddress:
+      "resource_rdx1t4a5clnxmnctmezaty08cuugfzmj2lezqcjk2szezrfdfl4w4ederu",
+    totalSupply: {
+      s: 1,
+      e: 5,
+      c: [388614, 19012744931796, 34910000000000],
+    },
+    poolResources: [
+      {
+        resourceAddress:
+          "resource_rdx1t5ywq4c6nd2lxkemkv4uzt8v7x7smjcguzq5sgafwtasa6luq7fclq",
+        poolUnitValue: {
+          s: 1,
+          e: 1,
+          c: [25, 93085350915701, 88635900000000],
+        },
+      },
+    ],
+  },
+  {
+    address: "pool_rdx1c47jlmd9stptfy2a7e39wnjfechu72q9ggus29x0mqf98m8xt70rx2",
+    lpResourceAddress:
+      "resource_rdx1t5q26nr5t02pzf40tp9z999ex7d84szldnpqg8e459jyvztrxhqqls",
+    totalSupply: {
+      s: 1,
+      e: 5,
+      c: [213641, 80245601383777, 47670000000000],
+    },
+    poolResources: [
+      {
+        resourceAddress:
+          "resource_rdx1t4tjx4g3qzd98nayqxm7qdpj0a0u8ns6a0jrchq49dyfevgh6u0gj3",
+        poolUnitValue: {
+          s: 1,
+          e: 0,
+          c: [8, 69968000834051, 15112400000000],
+        },
+      },
+      {
+        resourceAddress:
+          "resource_rdx1t5ywq4c6nd2lxkemkv4uzt8v7x7smjcguzq5sgafwtasa6luq7fclq",
+        poolUnitValue: {
+          s: 1,
+          e: 1,
+          c: [26, 48307928507802, 62491600000000],
+        },
+      },
+    ],
+  },
+  {
+    address: "pool_rdx1c4scl7k67czs4e29skz0njvcmx4epmrjk4nkrkvsmt93rug7jcnagf",
+    lpResourceAddress:
+      "resource_rdx1t5swt0y0u6sdzycg02flamm3e6qljjgvpxeg5p5tw6jl7ssel0x369",
+    totalSupply: {
+      s: 1,
+      e: 5,
+      c: [113479, 29211656368741, 73010000000000],
+    },
+    poolResources: [
+      {
+        resourceAddress:
+          "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+        poolUnitValue: {
+          s: 1,
+          e: 0,
+          c: [1, 17583670976188, 11866500000000],
+        },
+      },
+    ],
+  },
+  {
+    address: "pool_rdx1c4xm5wfm92vh39dzszzv3huvdmvz73juhkw8vls0z4fg2vfr0wkv93",
+    lpResourceAddress:
+      "resource_rdx1tkuuhphx2rtdytucgt0ucnd4k8zymxdeta4xa2req93yuaup3s244u",
+    totalSupply: {
+      s: 1,
+      e: 4,
+      c: [15458, 46956062507114, 34920000000000],
+    },
+    poolResources: [
+      {
+        resourceAddress:
+          "resource_rdx1t5ywq4c6nd2lxkemkv4uzt8v7x7smjcguzq5sgafwtasa6luq7fclq",
+        poolUnitValue: {
+          s: 1,
+          e: 1,
+          c: [23, 5489930377575, 8489900000000],
+        },
+      },
+    ],
+  },
+  {
+    address: "pool_rdx1c5glrayedmn0utd44pqs8a3x52dw9aklq2g5f9ewxjxtm7xvjmussa",
+    lpResourceAddress:
+      "resource_rdx1thhth6tseavhurrgae898k9sht29f3yckzr6szct6zgheqdhxkus0t",
+    totalSupply: {
+      s: 1,
+      e: 5,
+      c: [630963, 83925784568971, 38690000000000],
+    },
+    poolResources: [
+      {
+        resourceAddress:
+          "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+        poolUnitValue: {
+          s: 1,
+          e: 0,
+          c: [1, 7147193417516, 53345800000000],
+        },
+      },
+    ],
+  },
+  {
+    address: "pool_rdx1c5pvssdmlgjh78anllzszh7alal666ayv8h6at3xmxmmpueqf7at4q",
+    lpResourceAddress:
+      "resource_rdx1thnmcry6e02x6ja73llm8z6pkrurvrsudgez4ammsp24r0v20rllxt",
+    totalSupply: {
+      s: 1,
+      e: 4,
+      c: [17167, 81149783945655, 41760000000000],
+    },
+    poolResources: [
+      {
+        resourceAddress:
+          "resource_rdx1thrvr3xfs2tarm2dl9emvs26vjqxu6mqvfgvqjne940jv0lnrrg7rw",
+        poolUnitValue: {
+          s: 1,
+          e: -1,
+          c: [39185115277195, 41561800000000],
+        },
+      },
+      {
+        resourceAddress:
+          "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+        poolUnitValue: {
+          s: 1,
+          e: 1,
+          c: [32, 79997879477759, 6638000000000],
+        },
+      },
+    ],
+  },
+  {
+    address: "pool_rdx1c5xlqz5uc62fzlsyl2f3ql6lx8upc75tdpe4f8cmys83lpqrrul976",
+    lpResourceAddress:
+      "resource_rdx1t4x7f34hec2jxtay6cvxvcq3skmkg9pwtr98m4dm7qfrvnaddlavgv",
+    totalSupply: {
+      s: 1,
+      e: -1,
+      c: [34774186037892, 87430000000000],
+    },
+    poolResources: [
+      {
+        resourceAddress:
+          "resource_rdx1t580qxc7upat7lww4l2c4jckacafjeudxj5wpjrrct0p3e82sq4y75",
+        poolUnitValue: {
+          s: 1,
+          e: -1,
+          c: [30261369708360, 95837000000000],
+        },
+      },
+      {
+        resourceAddress:
+          "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+        poolUnitValue: {
+          s: 1,
+          e: 6,
+          c: [2965626, 96447762627018, 50632100000000],
+        },
+      },
+    ],
+  },
+  {
+    address: "pool_rdx1c5z06xda4gjykyhupj4fjszdfhsye7h3mcsgwe5cvuz2vemwn7yjax",
+    lpResourceAddress:
+      "resource_rdx1tkdws0nvfwjnn2q62x4gqgelyt4t5z7cn58pwvrtf4zrxtdw2sem8x",
+    totalSupply: {
+      s: 1,
+      e: 5,
+      c: [127159, 76157729626444, 44700000000000],
+    },
+    poolResources: [
+      {
+        resourceAddress:
+          "resource_rdx1t4upr78guuapv5ept7d7ptekk9mqhy605zgms33mcszen8l9fac8vf",
+        poolUnitValue: {
+          s: 1,
+          e: -1,
+          c: [39063489371836, 68904100000000],
+        },
+      },
+      {
+        resourceAddress:
+          "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+        poolUnitValue: {
+          s: 1,
+          e: 1,
+          c: [32, 55726764010234, 72669300000000],
+        },
+      },
+    ],
+  },
+  {
+    address: "pool_rdx1ch62axcl22gnmhe5ajtwraukrxstxxqlq5c6p9n2y5qv0pgyqnhfry",
+    lpResourceAddress:
+      "resource_rdx1t5gr3wsf7jq28fvnpyfg4rwfkewynv67nnqjna9h5f7mwjuwcwegcj",
+    totalSupply: {
+      s: 1,
+      e: 6,
+      c: [1182439, 74177223307075, 32930000000000],
+    },
+    poolResources: [
+      {
+        resourceAddress:
+          "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+        poolUnitValue: {
+          s: 1,
+          e: 0,
+          c: [1, 11881551377400, 65800900000000],
+        },
+      },
+    ],
+  },
+  {
+    address: "pool_rdx1cht7hqhcnj2la96cygema5l32xwz26luunr9umlszy3s9gr78ppdzv",
+    lpResourceAddress:
+      "resource_rdx1th6ftl6twglqfz2s8ref2vr5nfccaeq2878p4996uq5duszkjhp2gl",
+    totalSupply: {
+      s: 1,
+      e: 5,
+      c: [273172, 23326867261802, 67100000000000],
+    },
+    poolResources: [
+      {
+        resourceAddress:
+          "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+        poolUnitValue: {
+          s: 1,
+          e: 0,
+          c: [1, 8299487691086, 59017200000000],
+        },
+      },
+    ],
+  },
+  {
+    address: "pool_rdx1chxn0nqj840r78t2ah5agchq4ue9p65q23nc9ckqfe0mmjstq8fyg0",
+    lpResourceAddress:
+      "resource_rdx1tknxlx2sy23qkg6twvnu3kqcd5l4daacq0n6mdam54upqgx50f4ju8",
+    totalSupply: {
+      s: 1,
+      e: 5,
+      c: [329492, 66237176167177, 96750000000000],
+    },
+    poolResources: [
+      {
+        resourceAddress:
+          "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+        poolUnitValue: {
+          s: 1,
+          e: 1,
+          c: [18, 52577519829531, 5004500000000],
+        },
+      },
+      {
+        resourceAddress:
+          "resource_rdx1t5ywq4c6nd2lxkemkv4uzt8v7x7smjcguzq5sgafwtasa6luq7fclq",
+        poolUnitValue: {
+          s: 1,
+          e: -2,
+          c: [3015951031669, 24269300000000],
+        },
+      },
+    ],
+  },
+  {
+    address: "pool_rdx1ckt7dhmt5gr9vdsgz3p62fm88pm7f69kzzqw2268f3negvgns2xkpa",
+    lpResourceAddress:
+      "resource_rdx1t5k00sp4jejklp8cx6nw7ecvhz7z07mfexgmdyflgqpflfvzv8v7wd",
+    totalSupply: {
+      s: 1,
+      e: 1,
+      c: [11, 65077991503275, 80260000000000],
+    },
+    poolResources: [
+      {
+        resourceAddress:
+          "resource_rdx1th88qcj5syl9ghka2g9l7tw497vy5x6zaatyvgfkwcfe8n9jt2npww",
+        poolUnitValue: {
+          s: 1,
+          e: -1,
+          c: [48701057367650, 14461200000000],
+        },
+      },
+      {
+        resourceAddress:
+          "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+        poolUnitValue: {
+          s: 1,
+          e: 4,
+          c: [89625, 62370345967362, 85718300000000],
+        },
+      },
+    ],
+  },
+].map((pool) => ({
+  address: pool.address,
+  lpResourceAddress: pool.lpResourceAddress,
+  totalSupply: deserializeBigNumber(pool.totalSupply),
+  poolResources: pool.poolResources.map((resource) => ({
+    resourceAddress: resource.resourceAddress,
+    poolUnitValue: deserializeBigNumber(resource.poolUnitValue),
+  })),
+}));

--- a/packages/api/src/common/dapps/defiplaza/getDefiPlazaPositions.test.ts
+++ b/packages/api/src/common/dapps/defiplaza/getDefiPlazaPositions.test.ts
@@ -1,16 +1,17 @@
 import { Effect, Layer } from "effect";
+import { it } from "@effect/vitest";
 import { GatewayApiClientLive } from "../../gateway/gatewayApiClient";
 import { GetEntityDetailsService } from "../../gateway/getEntityDetails";
-import { GetLedgerStateService } from "../../gateway/getLedgerState";
-
-import { EntityFungiblesPageService } from "../../gateway/entityFungiblesPage";
 
 import {
   GetDefiPlazaPositionsLive,
   GetDefiPlazaPositionsService,
 } from "./getDefiPlazaPositions";
 import { GetFungibleBalanceService } from "../../gateway/getFungibleBalance";
-import { GetResourcePoolUnitsLive } from "../../resource-pool/getResourcePoolUnits";
+import { GetResourcePoolUnitsService } from "../../resource-pool/getResourcePoolUnits";
+import { pools } from "./fixtures/pools";
+import { fungibleBalance } from "./fixtures/fungibleBalance";
+import { deserializeBigNumber } from "../../utils/deserializeBigNumber";
 
 const gatewayApiClientLive = GatewayApiClientLive;
 
@@ -18,43 +19,38 @@ const getEntityDetailsServiceLive = GetEntityDetailsService.Default.pipe(
   Layer.provide(gatewayApiClientLive)
 );
 
-const getLedgerStateLive = GetLedgerStateService.Default.pipe(
-  Layer.provide(gatewayApiClientLive)
-);
-
-const entityFungiblesPageServiceLive = EntityFungiblesPageService.Default.pipe(
-  Layer.provide(gatewayApiClientLive)
-);
-
-const getFungibleBalanceLive = GetFungibleBalanceService.Default.pipe(
-  Layer.provide(getEntityDetailsServiceLive),
-  Layer.provide(gatewayApiClientLive),
-  Layer.provide(entityFungiblesPageServiceLive),
-  Layer.provide(getLedgerStateLive)
-);
-
-const getResourcePoolUnitsServiceLive = GetResourcePoolUnitsLive.pipe(
-  Layer.provide(getFungibleBalanceLive),
-  Layer.provide(getEntityDetailsServiceLive),
-  Layer.provide(gatewayApiClientLive),
-  Layer.provide(entityFungiblesPageServiceLive)
-);
-
 const getDefiPlazaPositionsLive = GetDefiPlazaPositionsLive.pipe(
-  Layer.provide(getFungibleBalanceLive),
-  Layer.provide(getEntityDetailsServiceLive),
-
-  Layer.provide(getResourcePoolUnitsServiceLive),
-  Layer.provide(entityFungiblesPageServiceLive)
+  Layer.provide(getEntityDetailsServiceLive)
 );
 
 describe("GetDefiPlazaPositionsService", () => {
-  it("should get defi plaza positions", async () => {
-    const program = Effect.provide(
+  it.effect(
+    "should get defi plaza positions",
+    () =>
       Effect.gen(function* () {
-        const getDefiPlazaPositions = yield* GetDefiPlazaPositionsService;
+        const getDefiPlazaPositions = yield* Effect.provide(
+          GetDefiPlazaPositionsService,
+          getDefiPlazaPositionsLive
+        ).pipe(
+          Effect.provideService(
+            GetResourcePoolUnitsService,
+            new GetResourcePoolUnitsService(() =>
+              Effect.gen(function* () {
+                return pools;
+              })
+            )
+          ),
+          Effect.provideService(
+            GetFungibleBalanceService,
+            new GetFungibleBalanceService(() =>
+              Effect.gen(function* () {
+                return fungibleBalance;
+              })
+            )
+          )
+        );
 
-        return yield* getDefiPlazaPositions({
+        const result = yield* getDefiPlazaPositions({
           accountAddresses: [
             // contains xUSDC BaseLP tokens
             "account_rdx12x2a5dft0gszufcce98ersqvsd8qr5kzku968jd50n8w4qyl9awecr",
@@ -63,20 +59,171 @@ describe("GetDefiPlazaPositionsService", () => {
             timestamp: new Date("2025-06-17T00:00:00Z"),
           },
         });
+
+        const expected = [
+          {
+            address:
+              "account_rdx12x2a5dft0gszufcce98ersqvsd8qr5kzku968jd50n8w4qyl9awecr",
+            items: [
+              {
+                lpResourceAddress:
+                  "resource_rdx1tkdws0nvfwjnn2q62x4gqgelyt4t5z7cn58pwvrtf4zrxtdw2sem8x",
+                position: [
+                  {
+                    resourceAddress:
+                      "resource_rdx1t4upr78guuapv5ept7d7ptekk9mqhy605zgms33mcszen8l9fac8vf",
+                    amount: {
+                      s: 1,
+                      e: 0,
+                      c: [7, 51502246182330, 84573034350913, 20194622710000],
+                    },
+                  },
+                  {
+                    resourceAddress:
+                      "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+                    amount: {
+                      s: 1,
+                      e: 2,
+                      c: [626, 33574610300727, 93930981736376, 54973734830000],
+                    },
+                  },
+                ],
+              },
+              {
+                lpResourceAddress:
+                  "resource_rdx1thnmcry6e02x6ja73llm8z6pkrurvrsudgez4ammsp24r0v20rllxt",
+                position: [
+                  {
+                    resourceAddress:
+                      "resource_rdx1thrvr3xfs2tarm2dl9emvs26vjqxu6mqvfgvqjne940jv0lnrrg7rw",
+                    amount: {
+                      s: 1,
+                      e: 0,
+                      c: [0],
+                    },
+                  },
+                  {
+                    resourceAddress:
+                      "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+                    amount: {
+                      s: 1,
+                      e: 0,
+                      c: [0],
+                    },
+                  },
+                ],
+              },
+              {
+                lpResourceAddress:
+                  "resource_rdx1t5k00sp4jejklp8cx6nw7ecvhz7z07mfexgmdyflgqpflfvzv8v7wd",
+                position: [
+                  {
+                    resourceAddress:
+                      "resource_rdx1th88qcj5syl9ghka2g9l7tw497vy5x6zaatyvgfkwcfe8n9jt2npww",
+                    amount: {
+                      s: 1,
+                      e: 0,
+                      c: [0],
+                    },
+                  },
+                  {
+                    resourceAddress:
+                      "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+                    amount: {
+                      s: 1,
+                      e: 0,
+                      c: [0],
+                    },
+                  },
+                ],
+              },
+              {
+                lpResourceAddress:
+                  "resource_rdx1t4x7f34hec2jxtay6cvxvcq3skmkg9pwtr98m4dm7qfrvnaddlavgv",
+                position: [
+                  {
+                    resourceAddress:
+                      "resource_rdx1t580qxc7upat7lww4l2c4jckacafjeudxj5wpjrrct0p3e82sq4y75",
+                    amount: {
+                      s: 1,
+                      e: 0,
+                      c: [0],
+                    },
+                  },
+                  {
+                    resourceAddress:
+                      "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+                    amount: {
+                      s: 1,
+                      e: 0,
+                      c: [0],
+                    },
+                  },
+                ],
+              },
+              {
+                lpResourceAddress:
+                  "resource_rdx1t5q26nr5t02pzf40tp9z999ex7d84szldnpqg8e459jyvztrxhqqls",
+                position: [
+                  {
+                    resourceAddress:
+                      "resource_rdx1t4tjx4g3qzd98nayqxm7qdpj0a0u8ns6a0jrchq49dyfevgh6u0gj3",
+                    amount: {
+                      s: 1,
+                      e: 0,
+                      c: [0],
+                    },
+                  },
+                  {
+                    resourceAddress:
+                      "resource_rdx1t5ywq4c6nd2lxkemkv4uzt8v7x7smjcguzq5sgafwtasa6luq7fclq",
+                    amount: {
+                      s: 1,
+                      e: 0,
+                      c: [0],
+                    },
+                  },
+                ],
+              },
+              {
+                lpResourceAddress:
+                  "resource_rdx1tknxlx2sy23qkg6twvnu3kqcd5l4daacq0n6mdam54upqgx50f4ju8",
+                position: [
+                  {
+                    resourceAddress:
+                      "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+                    amount: {
+                      s: 1,
+                      e: 0,
+                      c: [0],
+                    },
+                  },
+                  {
+                    resourceAddress:
+                      "resource_rdx1t5ywq4c6nd2lxkemkv4uzt8v7x7smjcguzq5sgafwtasa6luq7fclq",
+                    amount: {
+                      s: 1,
+                      e: 0,
+                      c: [0],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ].map((item) => ({
+          ...item,
+          items: item.items.map((item) => ({
+            ...item,
+            position: item.position.map((item) => ({
+              ...item,
+              amount: deserializeBigNumber(item.amount),
+            })),
+          })),
+        }));
+
+        expect(JSON.stringify(result)).toEqual(JSON.stringify(expected));
       }),
-      Layer.mergeAll(
-        getDefiPlazaPositionsLive,
-        gatewayApiClientLive,
-        getLedgerStateLive,
-        getEntityDetailsServiceLive,
-        getFungibleBalanceLive,
-        getResourcePoolUnitsServiceLive,
-        entityFungiblesPageServiceLive
-      )
-    );
-
-    const [result] = await Effect.runPromise(program);
-
-    expect(result.items.length).toBeGreaterThan(0);
-  }, 30_000);
+    30_000
+  );
 });

--- a/packages/api/src/common/dapps/defiplaza/getDefiPlazaPositions.ts
+++ b/packages/api/src/common/dapps/defiplaza/getDefiPlazaPositions.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 import BigNumber from "bignumber.js";
 
 import {
@@ -15,15 +15,6 @@ import {
   type GetResourcePoolOutput,
   GetResourcePoolUnitsService,
 } from "../../resource-pool/getResourcePoolUnits";
-
-export class InvalidPoolResourceError extends Error {
-  readonly _tag = "InvalidPoolResourceError";
-  constructor(error: unknown) {
-    super(
-      `Invalid pool resource: ${error instanceof Error ? error.message : error}`
-    );
-  }
-}
 
 type DefiPlazaPosition = {
   lpResourceAddress: string;

--- a/packages/api/src/common/resource-pool/getResourcePoolUnits.ts
+++ b/packages/api/src/common/resource-pool/getResourcePoolUnits.ts
@@ -19,15 +19,9 @@ export type GetResourcePoolInput = {
   at_ledger_state: AtLedgerState;
 };
 
-export type GetResourcePoolOutput = {
-  address: string;
-  lpResourceAddress: string;
-  totalSupply: BigNumber;
-  poolResources: {
-    resourceAddress: string;
-    poolUnitValue: BigNumber;
-  }[];
-}[];
+export type GetResourcePoolOutput = Effect.Effect.Success<
+  Awaited<ReturnType<(typeof GetResourcePoolUnitsService)["Service"]>>
+>;
 
 export class GetResourcePoolUnitsService extends Effect.Service<GetResourcePoolUnitsService>()(
   "GetResourcePoolUnitsService",

--- a/packages/api/src/common/utils/deserializeBigNumber.ts
+++ b/packages/api/src/common/utils/deserializeBigNumber.ts
@@ -1,0 +1,62 @@
+import { BigNumber } from "bignumber.js";
+
+/**
+ * Deserializes a BigNumber from its internal JSON representation
+ * @param value - Object with {s, e, c} properties or a BigNumber-compatible value
+ * @returns BigNumber instance
+ */
+export function deserializeBigNumber(
+  value: { s: number; e: number; c: number[] } | string | number | BigNumber
+): BigNumber {
+  // If it's already a BigNumber, return it
+  if (BigNumber.isBigNumber(value)) {
+    return value;
+  }
+
+  // If it's a primitive type, use the constructor directly
+  if (typeof value === "string" || typeof value === "number") {
+    return new BigNumber(value);
+  }
+
+  // Handle the {s, e, c} format
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "s" in value &&
+    "e" in value &&
+    "c" in value
+  ) {
+    // Create a new BigNumber instance and directly assign the internal properties
+    // This is the most reliable way to reconstruct from the internal format
+    const bn = new BigNumber(0);
+    
+    // Override the internal properties
+    (bn as any).s = value.s;
+    (bn as any).e = value.e;
+    (bn as any).c = value.c.slice(); // Copy the coefficient array
+    
+    // Return the reconstructed BigNumber
+    return bn;
+  }
+
+  throw new Error("Invalid BigNumber format");
+}
+
+/**
+ * Type guard to check if a value is in BigNumber JSON format
+ */
+export function isBigNumberJSON(
+  value: unknown
+): value is { s: number; e: number; c: number[] } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "s" in value &&
+    "e" in value &&
+    "c" in value &&
+    typeof value.s === "number" &&
+    typeof value.e === "number" &&
+    Array.isArray(value.c) &&
+    value.c.every((n) => typeof n === "number")
+  );
+}


### PR DESCRIPTION
## Summary
- Add `deserializeBigNumber` utility function for converting internal BigNumber format `{s,e,c}` to BigNumber instances
- Create comprehensive test fixtures for DefiPlaza pools and fungible balances with deserialized BigNumber values
- Update getDefiPlazaPositions test to use fixtures instead of live API calls for better test reliability and performance

## Test plan
- [x] Verify `deserializeBigNumber` correctly converts internal BigNumber format to BigNumber instances
- [x] Confirm DefiPlaza test fixtures provide realistic test data
- [x] Ensure getDefiPlazaPositions test passes with fixture data
- [x] Check that all TypeScript types are properly maintained

🤖 Generated with [Claude Code](https://claude.ai/code)