### PR TITLE
Fix: Correct activity ID pattern matching for hold activities

### DIFF
--- a/packages/api/src/incentives/activity-points/calculateTWASQL.ts
+++ b/packages/api/src/incentives/activity-points/calculateTWASQL.ts
@@ -70,8 +70,8 @@ export const CalculateTWASQLLive = Layer.effect(
                   AND jsonb_typeof(ab.data) = 'array'
                   AND ${
                     input.filterType === "exclude_hold"
-                      ? sql`(activity_item->>'activityId') NOT LIKE '%_ho_%'`
-                      : sql`(activity_item->>'activityId') LIKE '%_ho_%'`
+                      ? sql`(activity_item->>'activityId') NOT LIKE '%ho_%'`
+                      : sql`(activity_item->>'activityId') LIKE '%ho_%'`
                   }
               ),
               activities_with_duration AS (

--- a/packages/api/src/incentives/season-point-multiplier/getUserTWAXrdBalance.test.ts
+++ b/packages/api/src/incentives/season-point-multiplier/getUserTWAXrdBalance.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./getUserTWAXrdBalance";
 import { BigNumber } from "bignumber.js";
 import { eq } from "drizzle-orm";
+import { ActivityId } from "data";
 
 // Test data with proper UUIDs
 const testSeasonId = "550e8400-e29b-41d4-a716-446655440000";
@@ -99,7 +100,7 @@ const testData = {
       accountAddress: testAddresses[0],
       data: [
         {
-          activityId: "hold_maintainXrdBalance",
+          activityId: ActivityId.ho_xrd,
           usdValue: "1000.0",
         },
       ],
@@ -109,7 +110,7 @@ const testData = {
       accountAddress: testAddresses[0],
       data: [
         {
-          activityId: "hold_maintainXrdBalance",
+          activityId: ActivityId.ho_xrd,
           usdValue: "1500.0",
         },
       ],
@@ -120,7 +121,7 @@ const testData = {
       accountAddress: testAddresses[1],
       data: [
         {
-          activityId: "hold_maintainXrdBalance",
+          activityId: ActivityId.ho_xrd,
           usdValue: "500.0",
         },
       ],
@@ -130,7 +131,7 @@ const testData = {
       accountAddress: testAddresses[1],
       data: [
         {
-          activityId: "hold_maintainXrdBalance",
+          activityId: ActivityId.ho_xrd,
           usdValue: "750.0",
         },
       ],
@@ -141,7 +142,7 @@ const testData = {
       accountAddress: testAddresses[2],
       data: [
         {
-          activityId: "hold_maintainXrdBalance",
+          activityId: ActivityId.ho_xrd,
           usdValue: "2000.0",
         },
       ],

--- a/packages/api/src/incentives/season-point-multiplier/getUserTWAXrdBalance.ts
+++ b/packages/api/src/incentives/season-point-multiplier/getUserTWAXrdBalance.ts
@@ -59,10 +59,16 @@ export const GetUserTWAXrdBalanceLive = Layer.effect(
           calculationType: "USDValue",
           filterType: "include_hold",
           filterZeroValues: false,
-        }).pipe(
-          Effect.tap(() => Effect.log("Calculated TWA XRD balance using SQL")),
-          Effect.tap((items) => Effect.log(`Found ${items.length} hold activity entries`))
-        ).pipe(Effect.withSpan("calculateTWASQL"));
+        })
+          .pipe(
+            Effect.tap(() =>
+              Effect.log("Calculated TWA XRD balance using SQL")
+            ),
+            Effect.tap((items) =>
+              Effect.log(`Found ${items.length} hold activity entries`)
+            )
+          )
+          .pipe(Effect.withSpan("calculateTWASQL"));
 
         const getAccountsWithUserId = (createdAt: Date) => {
           return Effect.gen(function* () {
@@ -82,7 +88,7 @@ export const GetUserTWAXrdBalanceLive = Layer.effect(
             });
           }).pipe(Effect.withSpan("getAccountsWithUserId"));
         };
-        
+
         // accountsWithUserId is: Array<{ address: string, userId: string }>
         const accountsWithUserId = yield* getAccountsWithUserId(week.endDate);
 


### PR DESCRIPTION
## Summary
- Fixed activity ID pattern matching in TWA SQL calculation by removing extra underscore
- Updated tests to use proper `ActivityId` constants instead of hardcoded strings
- Applied minor code formatting improvements

## Test plan
- [x] Updated existing tests to use correct activity IDs
- [x] Tests pass with the corrected pattern matching
- [ ] Manual testing of hold activity calculations

🤖 Generated with [Claude Code](https://claude.ai/code)