### PR TITLE
Skip already registered accounts in account verification

### DIFF
--- a/packages/api/src/incentives/programs/verifyAccountOwnership.ts
+++ b/packages/api/src/incentives/programs/verifyAccountOwnership.ts
@@ -74,7 +74,13 @@ export const verifyAccountOwnershipProgram = (
       (account) => account.address,
     );
 
-    if (existingAccounts.length > 0) {
+    // Filter out accounts that are already registered
+    const remainingAccounts = input.items.filter(
+      (item) => !existingAccountAddresses.includes(item.address),
+    );
+
+    // If all accounts are already registered, fail
+    if (existingAccounts.length > 0 && remainingAccounts.length === 0) {
       return yield* Effect.fail(
         new AccountAlreadyRegisteredError(
           `accounts with addresses ${existingAccountAddresses.join(
@@ -84,9 +90,10 @@ export const verifyAccountOwnershipProgram = (
       );
     }
 
+    // Upsert remaining accounts
     const accounts = yield* upsertAccounts({
       userId: input.userId,
-      accounts: input.items,
+      accounts: remainingAccounts,
     });
 
     return accounts;


### PR DESCRIPTION
## Summary
- Modified verifyAccountOwnership to skip accounts that are already registered
- Only fails if all accounts are already registered
- Processes remaining unregistered accounts to improve user experience

## Test plan
- [ ] Test account registration with mix of new and existing accounts
- [ ] Verify that existing accounts are properly skipped
- [ ] Confirm error handling when all accounts are already registered
- [ ] Test successful registration of remaining new accounts

🤖 Generated with [Claude Code](https://claude.ai/code)