### PR TITLE
Add transaction stream enabled flag

### DIFF
--- a/packages/api/src/incentives/transaction-stream/transactionStreamLoopProgram.ts
+++ b/packages/api/src/incentives/transaction-stream/transactionStreamLoopProgram.ts
@@ -123,6 +123,15 @@ const transactionStreamLoopLive = TransactionStreamLoopService.Default.pipe(
 export const transactionStreamLoopProgram = () => {
   const runnable = Effect.provide(
     Effect.gen(function* () {
+      const transactionStreamEnabled = yield* Config.boolean(
+        'TRANSACTION_STREAM_ENABLED',
+      ).pipe(Config.withDefault(true));
+
+      if (!transactionStreamEnabled) {
+        yield* Effect.log('Transaction streamer is disabled');
+        return;
+      }
+
       const transactionStreamLoopService = yield* TransactionStreamLoopService;
       const configService = yield* ConfigService;
 


### PR DESCRIPTION
## Summary
- Added `TRANSACTION_STREAM_ENABLED` configuration flag to control whether the transaction streamer runs
- Allows disabling the transaction stream without code changes, useful for testing or maintenance
- Maintains backward compatibility by defaulting to `true`

## Changes
- **transactionStreamLoopProgram.ts**: 
  - Added config check for `TRANSACTION_STREAM_ENABLED` environment variable
  - Early return with log message when disabled
  - Prevents transaction stream initialization when flag is false

## Usage
```bash
# Disable transaction streamer
TRANSACTION_STREAM_ENABLED=false pnpm dev:workers

# Enable transaction streamer (default)
TRANSACTION_STREAM_ENABLED=true pnpm dev:workers
# or simply omit the variable
pnpm dev:workers
```

## Test plan
- [ ] Verify transaction streamer runs normally when flag is not set
- [ ] Verify transaction streamer runs when `TRANSACTION_STREAM_ENABLED=true`
- [ ] Verify transaction streamer does not initialize when `TRANSACTION_STREAM_ENABLED=false`
- [ ] Check that "Transaction streamer is disabled" message appears in logs when disabled

🤖 Generated with [Claude Code](https://claude.ai/code)