### PR TITLE
Add configurable event processing toggle to transaction stream

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -27,7 +27,8 @@
       "Bash(gh pr create:*)",
       "Bash(gh workflow:*)",
       "Bash(biome check:*)",
-      "Bash(pnpm biome check:*)"
+      "Bash(pnpm biome check:*)",
+      "Bash(git checkout:*)"
     ],
     "deny": []
   }

--- a/packages/api/src/incentives/transaction-stream/transactionStreamLoop.ts
+++ b/packages/api/src/incentives/transaction-stream/transactionStreamLoop.ts
@@ -1,4 +1,4 @@
-import { Effect } from 'effect';
+import { Config, Effect } from 'effect';
 import { AddComponentCallsService } from '../component/addComponentCalls';
 import { ConfigService } from '../config/configService';
 import { AddToEventQueueService } from '../events/addToEventQueue';
@@ -30,6 +30,11 @@ export class TransactionStreamLoopService extends Effect.Service<TransactionStre
       const addComponentCallsService = yield* AddComponentCallsService;
       const processSwapEventTradingVolumeService =
         yield* ProcessSwapEventTradingVolumeService;
+
+      const eventProcessingEnabled = yield* Config.boolean(
+        'TRANSACTION_STREAM_EVENT_PROCESSING_ENABLED',
+      ).pipe(Config.withDefault(true));
+
       return {
         run: Effect.fn(function* () {
           while (true) {
@@ -49,7 +54,7 @@ export class TransactionStreamLoopService extends Effect.Service<TransactionStre
               Effect.flatMap(filterTransactionsService),
             );
 
-            if (filteredTransactions.length > 0) {
+            if (filteredTransactions.length > 0 && eventProcessingEnabled) {
               // remove duplicate transactions using Map for O(n) performance
               const transactionMap = new Map(
                 filteredTransactions


### PR DESCRIPTION
## Summary
• Added TRANSACTION_STREAM_EVENT_PROCESSING_ENABLED environment variable to control event processing
• Allows disabling event processing while keeping transaction fetching active
• Provides better control over system resources and troubleshooting capabilities

## Test plan
- [ ] Verify transaction stream continues fetching when event processing is disabled
- [ ] Confirm event processing can be toggled via environment variable
- [ ] Test default behavior (enabled) works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)