### PR TITLE
Fix snapshot date range to include missing parameters

### DIFF
--- a/apps/workers/src/queues/snapshot-date-range/worker.ts
+++ b/apps/workers/src/queues/snapshot-date-range/worker.ts
@@ -29,6 +29,9 @@ export const snapshotDateRangeWorker = async (
         timestamp: date.toISOString(),
         addresses: input.data.addresses,
         addDummyData: input.data.addDummyData,
+        includeActivityIds: input.data.includeActivityIds,
+        usdThreshold: input.data.usdThreshold,
+        batchSize: input.data.batchSize,
       },
       {
         priority: SnapshotPriority.Scheduled,


### PR DESCRIPTION
## Summary
• Fixed snapshot date range worker to pass through all necessary parameters to individual snapshot jobs
• Ensures USD threshold, activity filters, and batch size are properly applied when creating snapshots from date ranges
• Resolves issue where these parameters were being dropped during job creation

## Changes
- Pass through `includeActivityIds` for activity filtering
- Pass through `usdThreshold` for USD threshold filtering  
- Pass through `batchSize` for controlling processing batch size

## Test plan
- [ ] Verify USD threshold is applied when using snapshot date range
- [ ] Confirm activity ID filtering works with date range snapshots
- [ ] Test that batch size parameter is respected

🤖 Generated with [Claude Code](https://claude.ai/code)