### PR TITLE
Fix batchSize and usdThreshold parameters not being passed to snapshot jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ apps/vote-collector/time_weighted_averages.csv
 
 # Claude code artifacts
 requirements
+
+packages/db/src/incentives/seed/data/accounts500KData.ts

--- a/tools/queue-helper/addItemToQueue.ts
+++ b/tools/queue-helper/addItemToQueue.ts
@@ -652,12 +652,14 @@ const buildPayload = (
               : undefined;
           })(),
         }),
-        ...(answers.usdThreshold && {
-          usdThreshold: answers.usdThreshold,
-        }),
-        ...(answers.batchSize && {
-          batchSize: answers.batchSize,
-        }),
+        ...(answers.usdThreshold !== undefined &&
+          (answers.usdThreshold as string).trim() !== '' && {
+            usdThreshold: answers.usdThreshold,
+          }),
+        ...(answers.batchSize !== undefined &&
+          answers.batchSize !== '' && {
+            batchSize: Number(answers.batchSize),
+          }),
       };
 
     case 'snapshot-date-range':
@@ -683,12 +685,14 @@ const buildPayload = (
               : undefined;
           })(),
         }),
-        ...(answers.usdThreshold && {
-          usdThreshold: answers.usdThreshold,
-        }),
-        ...(answers.batchSize && {
-          batchSize: answers.batchSize,
-        }),
+        ...(answers.usdThreshold !== undefined &&
+          (answers.usdThreshold as string).trim() !== '' && {
+            usdThreshold: answers.usdThreshold,
+          }),
+        ...(answers.batchSize !== undefined &&
+          answers.batchSize !== '' && {
+            batchSize: Number(answers.batchSize),
+          }),
       };
 
     case 'calculate-activity-points':


### PR DESCRIPTION
## Summary
• Fixed conditional logic that prevented batchSize and usdThreshold from being included when they had falsy values
• Updated both snapshot and snapshot-date-range queue payloads to properly check for undefined/empty values 
• Ensured batchSize is converted to number and usdThreshold remains as string per API requirements

## Test plan
- [ ] Test snapshot queue with usdThreshold parameter
- [ ] Test snapshot-date-range queue with both batchSize and usdThreshold parameters
- [ ] Verify parameters are properly passed to background jobs instead of using defaults

🤖 Generated with [Claude Code](https://claude.ai/code)