### PR TITLE
Fix snapshot processing and merge conflicts

### DIFF
--- a/apps/workers/src/queues/snapshot/worker.ts
+++ b/apps/workers/src/queues/snapshot/worker.ts
@@ -10,6 +10,9 @@ export const snapshotWorker = async (input: Job<SnapshotJob>) => {
     addresses: input.data.addresses,
     timestamp: new Date(input.data.timestamp),
     addDummyData: input.data.addDummyData,
+    includeActivityIds: input.data.includeActivityIds,
+    usdThreshold: input.data.usdThreshold,
+    batchSize: input.data.batchSize,
   });
 
   if (Exit.isFailure(result)) {

--- a/packages/api/src/incentives/snapshot/snapshot.ts
+++ b/packages/api/src/incentives/snapshot/snapshot.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js';
 import { Config, Data, Effect } from 'effect';
 import { z } from 'zod';
 import { chunker } from '../../common';

--- a/packages/api/src/incentives/snapshot/snapshotWorker.ts
+++ b/packages/api/src/incentives/snapshot/snapshotWorker.ts
@@ -11,6 +11,8 @@ export const snapshotJobSchema = z.object({
   addDummyData: z.boolean().optional(),
   jobId: z.string(),
   batchSize: z.number().optional(),
+  usdThreshold: z.string().optional(),
+  includeActivityIds: z.array(z.string()).optional(),
 });
 
 export type SnapshotWorkerInput = z.infer<typeof snapshotJobSchema>;


### PR DESCRIPTION
## Summary
• Resolve merge conflicts in snapshot worker files
• Add BigNumber import for snapshot processing functionality
• Ensure proper parameter passing from queue jobs to snapshot service
• Update snapshot worker to handle batchSize and usdThreshold parameters properly

## Test plan
- [ ] Verify snapshot worker processes jobs with batchSize and usdThreshold parameters correctly
- [ ] Test merge conflict resolution doesn't break existing functionality
- [ ] Confirm BigNumber import is working for snapshot calculations

🤖 Generated with [Claude Code](https://claude.ai/code)