### PR TITLE
Fix: Handle missing token prices gracefully

### DIFF
--- a/packages/api/src/incentives/token-price/getUsdValue.test.ts
+++ b/packages/api/src/incentives/token-price/getUsdValue.test.ts
@@ -1,7 +1,8 @@
+import { it } from '@effect/vitest';
 import { BigNumber } from 'bignumber.js';
 import { Assets } from 'data';
 import { Effect, Layer } from 'effect';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, vi } from 'vitest';
 import { AddressValidationServiceLive } from '../../common/address-validation/addressValidation';
 import { FetchService } from '../../common/helpers';
 import { GetUsdValueLive, GetUsdValueService } from './getUsdValue';
@@ -17,6 +18,8 @@ describe('GetUsdValueService', () => {
   const getUsdValueLive = GetUsdValueLive.pipe(
     Layer.provide(AddressValidationServiceLive),
   );
+
+  const fetchServiceLive = FetchService.Default;
 
   it('should return USD value for xUSDC', async () => {
     const amount = new BigNumber('100');
@@ -164,4 +167,26 @@ describe('GetUsdValueService', () => {
       name: expect.stringContaining('PriceServiceApiError'),
     });
   });
+
+  it.effect('should return 0 if price is missing', () =>
+    Effect.gen(function* () {
+      const getUsdValueLive = GetUsdValueLive.pipe(
+        Layer.provide(AddressValidationServiceLive),
+        Layer.provide(fetchServiceLive),
+      );
+
+      const getUsdService = yield* Effect.provide(
+        GetUsdValueService,
+        getUsdValueLive,
+      );
+
+      const result = yield* getUsdService({
+        amount: new BigNumber('100'),
+        resourceAddress: Assets.Fungible.EARLY,
+        timestamp: new Date('2024-01-01'),
+      });
+
+      expect(result.toString()).toBe('0');
+    }),
+  );
 });

--- a/packages/api/src/incentives/token-price/getUsdValue.ts
+++ b/packages/api/src/incentives/token-price/getUsdValue.ts
@@ -22,12 +22,6 @@ export class PriceServiceApiError extends Data.TaggedError(
   timestamp: number;
 }> {}
 
-class MissingPriceError extends Data.TaggedError('MissingPriceError')<{
-  message: string;
-  resourceAddress: string;
-  timestamp: number;
-}> {}
-
 type PriceCacheKey = `${string}:${number}`;
 
 export class GetUsdValueService extends Effect.Service<GetUsdValueService>()(
@@ -86,13 +80,7 @@ export class GetUsdValueService extends Effect.Service<GetUsdValueService>()(
           });
 
           if (responseText.includes('Price missing for tokens')) {
-            return yield* Effect.fail(
-              new MissingPriceError({
-                message: 'Price missing for tokens',
-                resourceAddress,
-                timestamp,
-              }),
-            );
+            return yield* Effect.succeed(new BigNumber(0));
           }
 
           return yield* Effect.fail(


### PR DESCRIPTION
## Summary
- Changed GetUsdValueService to return 0 instead of throwing error when token price data is missing
- Prevents calculation failures when historical price data is unavailable for certain tokens

## Test plan
- [x] Added unit test to verify the service returns 0 for missing prices
- [x] All existing tests pass
- [ ] Manual testing with tokens that have missing price data

🤖 Generated with [Claude Code](https://claude.ai/code)