### PR TITLE
feat: add transaction stream API service for state management

### DIFF
--- a/packages/api/src/common/gateway/getLedgerState.ts
+++ b/packages/api/src/common/gateway/getLedgerState.ts
@@ -11,6 +11,7 @@ export type GetLedgerStateInput = {
 export class GetLedgerStateService extends Effect.Service<GetLedgerStateService>()(
   'GetLedgerStateService',
   {
+    dependencies: [GatewayApiClientService.Default],
     effect: Effect.gen(function* () {
       const gatewayClient = yield* GatewayApiClientService;
       return Effect.fn('getLedgerStateService')(function* (

--- a/packages/api/src/incentives/admin/adminRouter.ts
+++ b/packages/api/src/incentives/admin/adminRouter.ts
@@ -168,37 +168,11 @@ export const adminRouter = createTRPCRouter({
     }),
     setState: publicProcedure
       .input(z.object({ state: z.enum(['START', 'PAUSE']) }))
-      .mutation(async ({ input }) => {
-        const response = await fetch(
-          `${process.env.STREAMER_API_BASE_URL}/state`,
-          {
-            method: 'POST',
-            body: JSON.stringify(input),
-          },
-        );
-
-        const json = await response.json();
-
-        if (!response.ok) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: JSON.stringify(json),
-          });
-        }
-
-        return json;
-      }),
-    setStateVersion: publicProcedure
-      .input(z.object({ timestamp: z.date() }))
       .mutation(async ({ input, ctx }) => {
-        const result = await ctx.dependencyLayer.getLedgerState({
-          at_ledger_state: {
-            timestamp: input.timestamp,
-          },
-        });
+        const result = await ctx.dependencyLayer.setState(input);
 
-        const stateVersion = Exit.match(result, {
-          onSuccess: (value) => value.state_version,
+        return Exit.match(result, {
+          onSuccess: (value) => value,
           onFailure: (error) => {
             console.error(error);
             throw new TRPCError({
@@ -206,25 +180,21 @@ export const adminRouter = createTRPCRouter({
             });
           },
         });
+      }),
+    setStateVersion: publicProcedure
+      .input(z.object({ timestamp: z.date() }))
+      .mutation(async ({ input, ctx }) => {
+        const result = await ctx.dependencyLayer.setStateVersion(input);
 
-        const response = await fetch(
-          `${process.env.STREAMER_API_BASE_URL}/state-version`,
-          {
-            method: 'POST',
-            body: JSON.stringify({ stateVersion }),
+        return Exit.match(result, {
+          onSuccess: (value) => value,
+          onFailure: (error) => {
+            console.error(error);
+            throw new TRPCError({
+              code: 'INTERNAL_SERVER_ERROR',
+            });
           },
-        );
-
-        const json = await response.json();
-
-        if (!response.ok) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: JSON.stringify(json),
-          });
-        }
-
-        return json;
+        });
       }),
   },
 });

--- a/packages/api/src/incentives/transaction-stream/transactionStreamApi.ts
+++ b/packages/api/src/incentives/transaction-stream/transactionStreamApi.ts
@@ -1,0 +1,127 @@
+import { Config, Data, Effect } from 'effect';
+import { z } from 'zod';
+import { FetchService } from '../../common';
+import { GetLedgerStateService } from '../../common/gateway';
+
+class RequestError extends Data.TaggedError('RequestError')<{
+  error: unknown;
+}> {}
+
+class ErrorResponse extends Data.TaggedError('ErrorResponse')<{
+  status: number;
+  message: string;
+}> {}
+
+class ValidationError extends Data.TaggedError('ValidationError')<{
+  message: string;
+}> {}
+
+type StateVersionResponse = {
+  message: string;
+  stateVersion: number;
+};
+
+type StateResponse = {
+  message: string;
+  state: 'PAUSED' | 'RUNNING';
+};
+
+export type SetStateVersionInput = {
+  timestamp: Date;
+};
+
+export const SetStateInputSchema = z.object({
+  state: z.enum(['START', 'PAUSE']),
+});
+
+export type SetStateInput = z.infer<typeof SetStateInputSchema>;
+
+export class TransactionStreamApiService extends Effect.Service<TransactionStreamApiService>()(
+  'TransactionStreamApiService',
+  {
+    dependencies: [FetchService.Default, GetLedgerStateService.Default],
+    effect: Effect.gen(function* () {
+      const fetchImp = yield* FetchService;
+      const getLedgerState = yield* GetLedgerStateService;
+
+      return {
+        setState: Effect.fn(function* (input: SetStateInput) {
+          const validatedInput = SetStateInputSchema.safeParse(input);
+
+          if (!validatedInput.success) {
+            return yield* Effect.fail(
+              new ValidationError({
+                message: validatedInput.error.message,
+              }),
+            );
+          }
+
+          const streamerApiBaseUrl = yield* Config.string(
+            'STREAMER_API_BASE_URL',
+          );
+
+          const response = yield* Effect.tryPromise({
+            try: () =>
+              fetchImp(`${streamerApiBaseUrl}/state`, {
+                method: 'POST',
+                body: JSON.stringify(input),
+              }),
+            catch: (error) => new RequestError({ error }),
+          });
+
+          if (!response.ok) {
+            const text = yield* Effect.tryPromise(() => response.text());
+
+            return yield* Effect.fail(
+              new ErrorResponse({
+                status: response.status,
+                message: text,
+              }),
+            );
+          }
+
+          const json = yield* Effect.tryPromise(() => response.json());
+
+          return json as StateResponse;
+        }),
+        setStateVersion: Effect.fn(function* (input: { timestamp: Date }) {
+          const streamerApiBaseUrl = yield* Config.string(
+            'STREAMER_API_BASE_URL',
+          );
+
+          const result = yield* getLedgerState({
+            at_ledger_state: {
+              timestamp: input.timestamp,
+            },
+          });
+
+          const stateVersion = result.state_version;
+
+          const response = yield* Effect.tryPromise({
+            try: () =>
+              fetchImp(`${streamerApiBaseUrl}/state-version`, {
+                method: 'POST',
+                body: JSON.stringify({ stateVersion }),
+              }),
+            catch: (error) => new RequestError({ error }),
+          });
+
+          if (!response.ok) {
+            const text = yield* Effect.tryPromise(() => response.text());
+
+            return yield* Effect.fail(
+              new ErrorResponse({
+                status: response.status,
+                message: text,
+              }),
+            );
+          }
+
+          const json = yield* Effect.tryPromise(() => response.json());
+
+          return json as StateVersionResponse;
+        }),
+      };
+    }),
+  },
+) {}

--- a/packages/api/src/incentives/trpc/createDependencyLayer.ts
+++ b/packages/api/src/incentives/trpc/createDependencyLayer.ts
@@ -81,6 +81,11 @@ import { GenerateSessionTokenLive } from '../session/generateSessionToken';
 import { GetSessionLive } from '../session/getSession';
 import { InvalidateSessionLive } from '../session/invalidateSession';
 import {
+  type SetStateInput,
+  type SetStateVersionInput,
+  TransactionStreamApiService,
+} from '../transaction-stream/transactionStreamApi';
+import {
   GetUsersPaginatedLive,
   GetUsersPaginatedService,
 } from '../user/getUsersPaginated';
@@ -815,6 +820,22 @@ export const createDependencyLayer = (input: CreateDependencyLayerInput) => {
     return Effect.runPromiseExit(program);
   };
 
+  const setStateVersion = (input: SetStateVersionInput) => {
+    const program = Effect.gen(function* () {
+      const transactionStreamApiService = yield* TransactionStreamApiService;
+      return yield* transactionStreamApiService.setStateVersion(input);
+    }).pipe(Effect.provide(TransactionStreamApiService.Default));
+    return Effect.runPromiseExit(program);
+  };
+
+  const setState = (input: SetStateInput) => {
+    const program = Effect.gen(function* () {
+      const transactionStreamApiService = yield* TransactionStreamApiService;
+      return yield* transactionStreamApiService.setState(input);
+    }).pipe(Effect.provide(TransactionStreamApiService.Default));
+    return Effect.runPromiseExit(program);
+  };
+
   return {
     createChallenge,
     signIn,
@@ -855,5 +876,7 @@ export const createDependencyLayer = (input: CreateDependencyLayerInput) => {
     getTransactionStreamState,
     getTransactionStreamStateVersion,
     getLedgerState,
+    setStateVersion,
+    setState,
   };
 };


### PR DESCRIPTION
## Summary
- Added new TransactionStreamApiService with setState and setStateVersion methods for controlling transaction stream state
- Integrated the service into the dependency layer to enable admin router access
- Refactored admin router to use dependency layer methods instead of direct HTTP calls

## Test plan
- [ ] Test setState endpoint with 'START' and 'PAUSE' actions via admin interface
- [ ] Test setStateVersion endpoint with valid timestamp
- [ ] Verify error handling for invalid inputs
- [ ] Confirm integration with existing admin routes

🤖 Generated with [Claude Code](https://claude.ai/code)