### PR TITLE
feat: add season points UI to admin dashboard

### DIFF
--- a/apps/admin/src/app/seasons/[seasonId]/weeks/[weekId]/components/adminWeekDetailsPage.tsx
+++ b/apps/admin/src/app/seasons/[seasonId]/weeks/[weekId]/components/adminWeekDetailsPage.tsx
@@ -26,6 +26,8 @@ const AdminWeekDetails: React.FC<AdminWeekDetailsProps> = ({
 
       <WeekControls
         weekData={weekData}
+        seasonId={seasonId}
+        weekId={weekId}
         onProcessWeek={onProcessWeek}
         onTriggerActivityPoints={onTriggerActivityPoints}
       />

--- a/apps/admin/src/app/seasons/[seasonId]/weeks/[weekId]/season-points/page.tsx
+++ b/apps/admin/src/app/seasons/[seasonId]/weeks/[weekId]/season-points/page.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { ArrowLeft, Loader2 } from 'lucide-react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { Button } from '~/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/components/ui/card';
+import { Separator } from '~/components/ui/separator';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '~/components/ui/table';
+import { api } from '~/trpc/react';
+
+export default function SeasonPointsPage() {
+  const params = useParams<{ seasonId: string; weekId: string }>();
+  const {
+    data: seasonPoints,
+    isLoading,
+    error,
+  } = api.admin.user.getSeasonPoints.useQuery({
+    weekId: params.weekId,
+  });
+
+  if (error) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="rounded-lg border border-destructive/20 bg-destructive/10 p-4">
+          <h2 className="mb-2 font-semibold text-destructive">
+            Error loading season points
+          </h2>
+          <p className="text-muted-foreground text-sm">{error.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="flex items-center justify-center py-12">
+          <div className="flex items-center gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>Loading season points...</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-6 pr-6 pl-6">
+      {/* Header Section */}
+      <div className="mb-6 flex items-center gap-4">
+        <Button variant="ghost" size="icon" asChild>
+          <Link
+            href={`/seasons/${params.seasonId}/weeks/${params.weekId}`}
+            aria-label="Back to week"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </Link>
+        </Button>
+        <div>
+          <h1 className="font-bold text-3xl tracking-tight">Season Points</h1>
+          <p className="text-muted-foreground">
+            Season points for week {params.weekId}
+          </p>
+        </div>
+      </div>
+
+      <Separator className="my-6" />
+
+      {/* Season Points Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>User Season Points</CardTitle>
+          <CardDescription>
+            {seasonPoints?.length || 0} user
+            {seasonPoints?.length !== 1 ? 's' : ''} with season points for this
+            week
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0">
+          <div className="overflow-hidden rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>User ID</TableHead>
+                  <TableHead className="text-right">Season Points</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {seasonPoints && seasonPoints.length > 0 ? (
+                  seasonPoints.map((point) => (
+                    <TableRow key={point.userId}>
+                      <TableCell className="font-mono text-sm">
+                        {point.userId}
+                      </TableCell>
+                      <TableCell className="text-right font-mono">
+                        {Number(point.points).toLocaleString(undefined, {
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 6,
+                        })}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={2} className="h-24 text-center">
+                      No season points found for this week.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/admin/src/components/week-details/week-controls.tsx
+++ b/apps/admin/src/components/week-details/week-controls.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Calculator, CheckCircle } from 'lucide-react';
+import { Calculator, CheckCircle, TrendingUp } from 'lucide-react';
+import Link from 'next/link';
 
 import {
   AlertDialog,
@@ -20,12 +21,16 @@ import type { WeekDetailsData } from './types';
 
 interface WeekControlsProps {
   weekData: WeekDetailsData;
+  seasonId?: string;
+  weekId?: string;
   onProcessWeek: () => void;
   onTriggerActivityPoints: () => void;
 }
 
 export const WeekControls: React.FC<WeekControlsProps> = ({
   weekData,
+  seasonId,
+  weekId,
   onProcessWeek,
   onTriggerActivityPoints,
 }) => {
@@ -39,6 +44,14 @@ export const WeekControls: React.FC<WeekControlsProps> = ({
           </p>
         </div>
         <ButtonGroup>
+          {seasonId && weekId && (
+            <Button variant="outline" asChild>
+              <Link href={`/seasons/${seasonId}/weeks/${weekId}/season-points`}>
+                <TrendingUp className="mr-2 h-4 w-4" />
+                Season Points
+              </Link>
+            </Button>
+          )}
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <Button variant="outline">

--- a/packages/api/src/incentives/admin/adminRouter.ts
+++ b/packages/api/src/incentives/admin/adminRouter.ts
@@ -6,6 +6,7 @@ import {
   db,
   seasonPointsMultiplier,
   user,
+  userSeasonPoints,
 } from 'db/incentives';
 import { and, count, eq } from 'drizzle-orm';
 import { Exit } from 'effect';
@@ -43,6 +44,18 @@ export const adminRouter = createTRPCRouter({
       .query(async ({ input }) => {
         return db.query.accountActivityPoints.findMany({
           where: and(eq(accountActivityPoints.accountAddress, input.address)),
+        });
+      }),
+
+    getSeasonPoints: publicProcedure
+      .input(
+        z.object({
+          weekId: z.string(),
+        }),
+      )
+      .query(async ({ input }) => {
+        return db.query.userSeasonPoints.findMany({
+          where: eq(userSeasonPoints.weekId, input.weekId),
         });
       }),
 


### PR DESCRIPTION
## Summary
- Created season points page displaying user IDs and points in a table format
- Added "Season Points" navigation link from week details page
- Updated WeekControls component to support navigation with seasonId and weekId props

## Test plan
- [ ] Navigate to a week details page in the admin dashboard
- [ ] Click the "Season Points" button in the Week Management section
- [ ] Verify the season points page loads and displays user points data
- [ ] Verify the back button returns to the week details page
- [ ] Test with weeks that have no season points data

🤖 Generated with [Claude Code](https://claude.ai/code)