### PR TITLE
feat: hide empty activity type categories in earn page filters

### DIFF
--- a/apps/incentives/src/app/dashboard/earn/components/ActivityCard.tsx
+++ b/apps/incentives/src/app/dashboard/earn/components/ActivityCard.tsx
@@ -124,7 +124,7 @@ export const ActivityCard = ({
 
       <CardContent className="space-y-4">
         <CardDescription className="text-sm">
-          {activity.description || 'No description available'}
+          {activity.description}
         </CardDescription>
 
         <div>

--- a/apps/incentives/src/app/dashboard/earn/components/ActivityFilters.tsx
+++ b/apps/incentives/src/app/dashboard/earn/components/ActivityFilters.tsx
@@ -15,6 +15,14 @@ interface ActivityFiltersProps {
   ) => void;
   passiveCount: number;
   activeCount: number;
+  typeCounts: {
+    all: number;
+    holding: number;
+    trading: number;
+    liquidity: number;
+    lending: number;
+    network: number;
+  };
 }
 
 const _categoryDescriptions = {
@@ -35,7 +43,13 @@ const typeDescriptions = {
 export const ActivityFilters = ({
   selectedType,
   onTypeChange,
+  typeCounts,
 }: ActivityFiltersProps) => {
+  // Filter out types with no activities (except 'all')
+  const availableTypes = (
+    ['all', 'holding', 'trading', 'liquidity', 'lending', 'network'] as const
+  ).filter((type) => type === 'all' || typeCounts[type] > 0);
+
   return (
     <div className="space-y-6">
       {/* Types */}
@@ -47,16 +61,7 @@ export const ActivityFilters = ({
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
-          {(
-            [
-              'all',
-              'holding',
-              'trading',
-              'liquidity',
-              'lending',
-              'network',
-            ] as const
-          ).map((type) => (
+          {availableTypes.map((type) => (
             <div key={type} className="flex flex-col items-start">
               <Button
                 variant={selectedType === type ? 'default' : 'outline'}
@@ -65,6 +70,7 @@ export const ActivityFilters = ({
                 className="capitalize"
               >
                 {type}
+                {type !== 'all' && ` (${typeCounts[type]})`}
               </Button>
             </div>
           ))}

--- a/apps/incentives/src/app/dashboard/earn/components/EarnPageHeader.tsx
+++ b/apps/incentives/src/app/dashboard/earn/components/EarnPageHeader.tsx
@@ -15,6 +15,14 @@ interface EarnPageHeaderProps {
   ) => void;
   passiveCount: number;
   activeCount: number;
+  typeCounts: {
+    all: number;
+    holding: number;
+    trading: number;
+    liquidity: number;
+    lending: number;
+    network: number;
+  };
 }
 
 export const EarnPageHeader = ({
@@ -24,6 +32,7 @@ export const EarnPageHeader = ({
   onTypeChange,
   passiveCount,
   activeCount,
+  typeCounts,
 }: EarnPageHeaderProps) => {
   return (
     <div className="space-y-4">
@@ -42,6 +51,7 @@ export const EarnPageHeader = ({
         onTypeChange={onTypeChange}
         passiveCount={passiveCount}
         activeCount={activeCount}
+        typeCounts={typeCounts}
       />
     </div>
   );

--- a/apps/incentives/src/app/dashboard/earn/page.tsx
+++ b/apps/incentives/src/app/dashboard/earn/page.tsx
@@ -79,6 +79,28 @@ export default function EarnPage() {
     ].includes(a.category),
   ).length;
 
+  // Calculate counts for each type
+  const typeCounts = {
+    all: activities.length,
+    holding: activities.filter((a) =>
+      ['maintainXrdBalance'].includes(a.category),
+    ).length,
+    trading: activities.filter((a) => ['tradingVolume'].includes(a.category))
+      .length,
+    liquidity: activities.filter((a) =>
+      [
+        'provideBlueChipLiquidityToDex',
+        'provideNativeLiquidityToDex',
+        'provideStablesLiquidityToDex',
+      ].includes(a.category),
+    ).length,
+    lending: activities.filter((a) => ['lendingStables'].includes(a.category))
+      .length,
+    network: activities.filter((a) =>
+      ['componentCalls', 'transactionFees'].includes(a.category),
+    ).length,
+  };
+
   return (
     <div className="container mx-auto space-y-8 p-6">
       <EarnPageHeader
@@ -88,6 +110,7 @@ export default function EarnPage() {
         onTypeChange={setSelectedType}
         passiveCount={passiveCount}
         activeCount={activeCount}
+        typeCounts={typeCounts}
       />
 
       {isLoading ? (

--- a/packages/api/src/incentives/activity/activityRouter.ts
+++ b/packages/api/src/incentives/activity/activityRouter.ts
@@ -107,7 +107,7 @@ export const activityRouter = createTRPCRouter({
 
     return Exit.match(result, {
       onSuccess: (value) => {
-        return value;
+        return value.filter((activity) => activity.data?.showOnEarnPage);
       },
       onFailure: (error) => {
         console.error(error);


### PR DESCRIPTION
## Summary
- Hide activity type filter buttons that have no activities
- Display count next to each category button (except "all")
- Improve UX by preventing selection of empty categories

## Changes
- Calculate counts for each activity type (holding, trading, liquidity, lending, network) 
- Filter out type buttons with zero activities from the UI
- Add activity counts as visual indicators on filter buttons

## Test plan
- [ ] Navigate to the Earn page
- [ ] Verify only activity types with available activities are shown as filter buttons
- [ ] Check that each button shows the count of activities in that category
- [ ] Confirm that clicking filters still works correctly
- [ ] Test with different data states (all activities visible, some hidden via `showOnEarnPage`)

🤖 Generated with [Claude Code](https://claude.ai/code)