### PR TITLE
fix: prevent infinite retries in gateway API client

### DIFF
--- a/packages/api/src/common/gateway/gatewayApiClient.ts
+++ b/packages/api/src/common/gateway/gatewayApiClient.ts
@@ -33,7 +33,11 @@ export class GatewayApiClientService extends Effect.Service<GatewayApiClientServ
           const baseDelay = Math.min(2 ** attempt * 1000, maxDelay); // 1000, 2000, 4000ms etc up to max
           return Math.floor(baseDelay);
         },
-        retryOn: (_attempt, error, response) => {
+        retryOn: (attempt, error, response) => {
+          if (attempt > gatewayRetryAttempts) {
+            return false;
+          }
+
           // Retry on network errors
           if (error !== null) {
             return false;


### PR DESCRIPTION
## Summary
- Adds explicit retry attempt limit check in the gateway API client
- Prevents potential infinite retry loops when retryOn callback returns true
- Ensures proper termination after configured number of retry attempts

## Test Plan
- [ ] Verify gateway API client properly terminates after maximum retry attempts
- [ ] Test that the retry logic still works for retryable errors (5xx status codes)
- [ ] Confirm that non-retryable errors fail immediately

🤖 Generated with [Claude Code](https://claude.ai/code)