### PR TITLE
refactor: update services to use Effect.Service pattern

### DIFF
--- a/packages/api/src/incentives/component/addComponentCalls.ts
+++ b/packages/api/src/incentives/component/addComponentCalls.ts
@@ -2,9 +2,9 @@ import { utc } from '@date-fns/utc';
 import { endOfISOWeek, startOfISOWeek } from 'date-fns';
 import { componentCalls } from 'db/incentives';
 import { and, between, inArray, sql } from 'drizzle-orm';
-import { Context, Effect, Layer } from 'effect';
+import { Effect } from 'effect';
 import { groupBy } from 'effect/Array';
-import { DbClientService, DbError } from '../db/dbClient';
+import { DbService } from '../db/dbClient';
 import { GetUserIdByAccountAddressService } from '../user/getUserIdByAccountAddress';
 
 export type AddComponentCallsServiceInput = {
@@ -13,24 +13,17 @@ export type AddComponentCallsServiceInput = {
   componentAddresses: string[];
 }[];
 
-export class AddComponentCallsService extends Context.Tag(
-  'AddComponentCallsService',
-)<
-  AddComponentCallsService,
-  (input: AddComponentCallsServiceInput) => Effect.Effect<void, DbError>
->() {}
-
 type UserId = string;
 type ComponentAddress = string;
 
-export const AddComponentCallsLive = Layer.effect(
-  AddComponentCallsService,
-  Effect.gen(function* () {
-    const db = yield* DbClientService;
-    const getUserIdByAccountAddress = yield* GetUserIdByAccountAddressService;
-
-    return (input) => {
-      return Effect.gen(function* () {
+export class AddComponentCallsService extends Effect.Service<AddComponentCallsService>()(
+  'AddComponentCallsService',
+  {
+    dependencies: [DbService.Default, GetUserIdByAccountAddressService.Default],
+    effect: Effect.gen(function* () {
+      const db = yield* DbService;
+      const getUserIdByAccountAddress = yield* GetUserIdByAccountAddressService;
+      return Effect.fn(function* (input: AddComponentCallsServiceInput) {
         if (input.length === 0) return;
 
         const accountAddressUserIdMap = yield* getUserIdByAccountAddress(
@@ -86,26 +79,22 @@ export const AddComponentCallsLive = Layer.effect(
             .map((item) => accountAddressUserIdMap.get(item.accountAddress))
             .filter((userId) => userId !== undefined);
 
-          const result = yield* Effect.tryPromise({
-            try: () =>
-              db
-                .select({
-                  userId: componentCalls.userId,
-                  data: componentCalls.data,
-                })
-                .from(componentCalls)
-                .where(
-                  and(
-                    inArray(componentCalls.userId, userIds),
-                    between(
-                      componentCalls.timestamp,
-                      weekGroup.startDate,
-                      weekGroup.endDate,
-                    ),
-                  ),
+          const result = yield* db
+            .select({
+              userId: componentCalls.userId,
+              data: componentCalls.data,
+            })
+            .from(componentCalls)
+            .where(
+              and(
+                inArray(componentCalls.userId, userIds),
+                between(
+                  componentCalls.timestamp,
+                  weekGroup.startDate,
+                  weekGroup.endDate,
                 ),
-            catch: (error) => new DbError(error),
-          });
+              ),
+            );
 
           const componentCallMap = new Map<UserId, Set<ComponentAddress>>();
 
@@ -162,20 +151,16 @@ export const AddComponentCallsLive = Layer.effect(
           };
         });
 
-        yield* Effect.tryPromise({
-          try: () =>
-            db
-              .insert(componentCalls)
-              .values(itemsToInsert)
-              .onConflictDoUpdate({
-                target: [componentCalls.userId, componentCalls.timestamp],
-                set: { data: sql`excluded.data` },
-              }),
-          catch: (error) => new DbError(error),
-        });
+        yield* db
+          .insert(componentCalls)
+          .values(itemsToInsert)
+          .onConflictDoUpdate({
+            target: [componentCalls.userId, componentCalls.timestamp],
+            set: { data: sql`excluded.data` },
+          });
 
         return;
       });
-    };
-  }),
-);
+    }),
+  },
+) {}

--- a/packages/api/src/incentives/config/configService.ts
+++ b/packages/api/src/incentives/config/configService.ts
@@ -24,11 +24,13 @@ export class ConfigService extends Effect.Service<ConfigService>()(
       const getLedgerStateService = yield* GetLedgerStateService;
 
       const getConfigFromDb = Effect.fn(function* <T = unknown>(key: string) {
-        const result = yield* dbClient.query.config.findFirst({
-          where: eq(config.key, key),
-        });
+        const result = yield* dbClient
+          .select()
+          .from(config)
+          .where(eq(config.key, key))
+          .limit(1);
 
-        const value = result?.value as T | undefined;
+        const value = result?.[0]?.value as T | undefined;
 
         return value;
       });

--- a/packages/api/src/incentives/events/addToEventQueue.ts
+++ b/packages/api/src/incentives/events/addToEventQueue.ts
@@ -1,29 +1,21 @@
-import { Context, Effect, Layer } from 'effect';
+import { Effect } from 'effect';
 import {
   type EventQueueClientInput,
   EventQueueClientService,
-  type EventQueueClientServiceError,
 } from './eventQueueClient';
 
 type AddToEventQueueInput = EventQueueClientInput;
 
-export class AddToEventQueueService extends Context.Tag(
+export class AddToEventQueueService extends Effect.Service<AddToEventQueueService>()(
   'AddToEventQueueService',
-)<
-  AddToEventQueueService,
-  (
-    input: AddToEventQueueInput,
-  ) => Effect.Effect<void, EventQueueClientServiceError>
->() {}
-
-export const AddToEventQueueLive = Layer.effect(
-  AddToEventQueueService,
-  Effect.gen(function* () {
-    const eventQueueClientService = yield* EventQueueClientService;
-
-    return (input) =>
-      Effect.gen(function* () {
+  {
+    dependencies: [EventQueueClientService.Default],
+    effect: Effect.gen(function* () {
+      const eventQueueClientService = yield* EventQueueClientService;
+      return Effect.fn(function* (input: AddToEventQueueInput) {
+        // Implementation goes here
         yield* eventQueueClientService(input);
       });
-  }),
-);
+    }),
+  },
+) {}

--- a/packages/api/src/incentives/events/eventQueueClient.ts
+++ b/packages/api/src/incentives/events/eventQueueClient.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer } from 'effect';
+import { Config, Effect } from 'effect';
 import { z } from 'zod';
 
 export class AddToEventQueueError {
@@ -26,26 +26,13 @@ export type EventQueueClientServiceError =
   | AddToEventQueueError
   | AddToEventQueueInputSchemaError;
 
-export class EventQueueClientService extends Context.Tag(
+export class EventQueueClientService extends Effect.Service<EventQueueClientService>()(
   'EventQueueClientService',
-)<
-  EventQueueClientService,
-  (
-    input: EventQueueClientInput,
-  ) => Effect.Effect<void, EventQueueClientServiceError>
->() {}
+  {
+    effect: Effect.gen(function* () {
+      const workersApiBaseUrl = yield* Config.string('WORKERS_API_BASE_URL');
 
-export const EventQueueClientLive = Layer.effect(
-  EventQueueClientService,
-  Effect.gen(function* () {
-    const workersApiBaseUrl = process.env.WORKERS_API_BASE_URL;
-
-    if (!workersApiBaseUrl) {
-      return yield* Effect.dieMessage('WORKERS_API_BASE_URL is not set');
-    }
-
-    return (input) =>
-      Effect.gen(function* () {
+      return Effect.fn(function* (input: EventQueueClientInput) {
         const parsedInput = EventQueueClientServiceSchema.safeParse(input);
 
         if (!parsedInput.success) {
@@ -72,5 +59,6 @@ export const EventQueueClientLive = Layer.effect(
           );
         }
       });
-  }),
-);
+    }),
+  },
+) {}

--- a/packages/api/src/incentives/events/queries/addEventToDb.ts
+++ b/packages/api/src/incentives/events/queries/addEventToDb.ts
@@ -1,37 +1,28 @@
 import { type Event, events } from 'db/incentives';
-import { Context, Effect, Layer } from 'effect';
+import { Effect } from 'effect';
 import SuperJSON from 'superjson';
-import { DbClientService, DbError } from '../../db/dbClient';
+import { DbService } from '../../db/dbClient';
 
-export class AddEventsToDbService extends Context.Tag('AddEventsToDbService')<
-  AddEventsToDbService,
-  (input: Event[]) => Effect.Effect<Event[], DbError>
->() {}
+export class AddEventsToDbService extends Effect.Service<AddEventsToDbService>()(
+  'AddEventsToDbService',
+  {
+    dependencies: [DbService.Default],
+    effect: Effect.gen(function* () {
+      const db = yield* DbService;
 
-export const AddEventsToDbLive = Layer.effect(
-  AddEventsToDbService,
-  Effect.gen(function* () {
-    const db = yield* DbClientService;
-
-    return (input) => {
-      return Effect.gen(function* () {
-        const result = yield* Effect.tryPromise({
-          try: () =>
-            db
-              .insert(events)
-              .values(
-                input.map((item) => ({
-                  ...item,
-                  eventData: SuperJSON.serialize(item.eventData),
-                })),
-              )
-              .returning()
-              .onConflictDoNothing(),
-          catch: (error) => new DbError(error),
-        });
-
-        return result;
+      return Effect.fn(function* (input: Event[]) {
+        // Implementation goes here
+        return yield* db
+          .insert(events)
+          .values(
+            input.map((item) => ({
+              ...item,
+              eventData: SuperJSON.serialize(item.eventData),
+            })),
+          )
+          .returning()
+          .onConflictDoNothing();
       });
-    };
-  }),
-);
+    }),
+  },
+) {}

--- a/packages/api/src/incentives/trading-volume/addTradingVolume.ts
+++ b/packages/api/src/incentives/trading-volume/addTradingVolume.ts
@@ -1,8 +1,8 @@
 import type { ActivityId } from 'data';
 import { tradingVolume } from 'db/incentives';
 import { sql } from 'drizzle-orm';
-import { Context, Effect, Layer } from 'effect';
-import { DbClientService, DbError } from '../db/dbClient';
+import { Effect } from 'effect';
+import { DbService } from '../db/dbClient';
 
 export type AddTradingVolumeServiceInput = {
   accountAddress: string;
@@ -13,38 +13,24 @@ export type AddTradingVolumeServiceInput = {
   }[];
 }[];
 
-export class AddTradingVolumeService extends Context.Tag(
+export class AddTradingVolumeService extends Effect.Service<AddTradingVolumeService>()(
   'AddTradingVolumeService',
-)<
-  AddTradingVolumeService,
-  (input: AddTradingVolumeServiceInput) => Effect.Effect<void, DbError>
->() {}
-
-export const AddTradingVolumeLive = Layer.effect(
-  AddTradingVolumeService,
-  Effect.gen(function* () {
-    const db = yield* DbClientService;
-
-    return (input) => {
-      return Effect.gen(function* () {
-        if (input.length === 0) return;
-
-        const result = yield* Effect.tryPromise({
-          try: () =>
-            db
-              .insert(tradingVolume)
-              .values(input)
-              .onConflictDoUpdate({
-                target: [tradingVolume.accountAddress, tradingVolume.timestamp],
-                set: {
-                  data: sql`excluded.data`,
-                },
-              }),
-          catch: (error) => new DbError(error),
-        });
-
-        return result;
+  {
+    dependencies: [DbService.Default],
+    effect: Effect.gen(function* () {
+      const db = yield* DbService;
+      return Effect.fn(function* (input: AddTradingVolumeServiceInput) {
+        // Implementation goes here
+        return yield* db
+          .insert(tradingVolume)
+          .values(input)
+          .onConflictDoUpdate({
+            target: [tradingVolume.accountAddress, tradingVolume.timestamp],
+            set: {
+              data: sql`excluded.data`,
+            },
+          });
       });
-    };
-  }),
-);
+    }),
+  },
+) {}

--- a/packages/api/src/incentives/trading-volume/filterTradingEvents.ts
+++ b/packages/api/src/incentives/trading-volume/filterTradingEvents.ts
@@ -5,7 +5,10 @@ import {
   shapeLiquidityComponentSet,
 } from 'data';
 import { Effect } from 'effect';
-import { AddressValidationService } from '../../common/address-validation/addressValidation';
+import {
+  AddressValidationService,
+  AddressValidationServiceLive,
+} from '../../common/address-validation/addressValidation';
 import type { CaviarnineSwapEvent } from '../events/event-matchers/caviarnineEventMatcher';
 import type { CapturedEvent } from '../events/event-matchers/createEventMatcher';
 import type { DefiPlazaSwapEvent } from '../events/event-matchers/defiPlazaEventMatcher';
@@ -32,6 +35,7 @@ export type FilterTradingEventsOutput = Effect.Effect.Success<
 export class FilterTradingEventsService extends Effect.Service<FilterTradingEventsService>()(
   'FilterTradingEventsService',
   {
+    dependencies: [GetUsdValueService.Default, AddressValidationServiceLive],
     effect: Effect.gen(function* () {
       const getUsdValueService = yield* GetUsdValueService;
       const addressValidationService = yield* AddressValidationService;

--- a/packages/api/src/incentives/trading-volume/processSwapEventTradingVolume.ts
+++ b/packages/api/src/incentives/trading-volume/processSwapEventTradingVolume.ts
@@ -89,6 +89,10 @@ const processTransactionGroup = (
 export class ProcessSwapEventTradingVolumeService extends Effect.Service<ProcessSwapEventTradingVolumeService>()(
   'ProcessSwapEventTradingVolumeService',
   {
+    dependencies: [
+      AddTradingVolumeService.Default,
+      FilterTradingEventsService.Default,
+    ],
     effect: Effect.gen(function* () {
       const addTradingVolumeService = yield* AddTradingVolumeService;
       const filterTradingEventsService = yield* FilterTradingEventsService;

--- a/packages/api/src/incentives/transaction-fee/addTransactionFee.ts
+++ b/packages/api/src/incentives/transaction-fee/addTransactionFee.ts
@@ -1,7 +1,7 @@
 import type BigNumber from 'bignumber.js';
 import { transactionFees } from 'db/incentives';
-import { Context, Effect, Layer } from 'effect';
-import { DbClientService, DbError } from '../db/dbClient';
+import { Effect } from 'effect';
+import { DbService } from '../db/dbClient';
 
 export type AddTransactionFeeServiceInput = {
   txId: string;
@@ -10,39 +10,26 @@ export type AddTransactionFeeServiceInput = {
   timestamp: Date;
 }[];
 
-export class AddTransactionFeeService extends Context.Tag(
+export class AddTransactionFeeService extends Effect.Service<AddTransactionFeeService>()(
   'AddTransactionFeeService',
-)<
-  AddTransactionFeeService,
-  (input: AddTransactionFeeServiceInput) => Effect.Effect<void, DbError>
->() {}
-
-export const AddTransactionFeeLive = Layer.effect(
-  AddTransactionFeeService,
-  Effect.gen(function* () {
-    const db = yield* DbClientService;
-
-    return (input) => {
-      return Effect.gen(function* () {
-        if (input.length === 0) return;
-        const result = yield* Effect.tryPromise({
-          try: () =>
-            db
-              .insert(transactionFees)
-              .values(
-                input.map((t) => ({
-                  transactionId: t.txId,
-                  accountAddress: t.accountAddress,
-                  fee: t.fee.toString(),
-                  timestamp: t.timestamp,
-                })),
-              )
-              .onConflictDoNothing(),
-          catch: (error) => new DbError(error),
-        });
-
-        return result;
+  {
+    dependencies: [DbService.Default],
+    effect: Effect.gen(function* () {
+      const db = yield* DbService;
+      return Effect.fn(function* (input: AddTransactionFeeServiceInput) {
+        // Implementation goes here
+        return yield* db
+          .insert(transactionFees)
+          .values(
+            input.map((t) => ({
+              transactionId: t.txId,
+              accountAddress: t.accountAddress,
+              fee: t.fee.toString(),
+              timestamp: t.timestamp,
+            })),
+          )
+          .onConflictDoNothing();
       });
-    };
-  }),
-);
+    }),
+  },
+) {}

--- a/packages/api/src/incentives/transaction-stream/filterTransactions.ts
+++ b/packages/api/src/incentives/transaction-stream/filterTransactions.ts
@@ -2,8 +2,8 @@ import type { CommittedTransactionInfo } from '@radixdlt/babylon-gateway-api-sdk
 import Bignumber from 'bignumber.js';
 import { type Account, accounts } from 'db/incentives';
 import { inArray } from 'drizzle-orm';
-import { Context, Effect, Layer } from 'effect';
-import { DbClientService, DbError } from '../db/dbClient';
+import { Effect } from 'effect';
+import { DbError, DbService } from '../db/dbClient';
 import {
   type TransformedTransaction,
   transformTransactions,
@@ -23,26 +23,19 @@ export type FilterTransactionsServiceOutput = {
   stateVersion: number;
 };
 
-export class FilterTransactionsService extends Context.Tag(
-  'FilterTransactionsService',
-)<
-  FilterTransactionsService,
-  (input: {
-    transactions: CommittedTransactionInfo[];
-    stateVersion: number;
-  }) => Effect.Effect<FilterTransactionsServiceOutput, DbError>
->() {}
-
 type AccountAddress = string;
 type TransactionId = string;
 
-export const FilterTransactionsLive = Layer.effect(
-  FilterTransactionsService,
-  Effect.gen(function* () {
-    const dbClient = yield* DbClientService;
-
-    return (input) => {
-      return Effect.gen(function* () {
+export class FilterTransactionsService extends Effect.Service<FilterTransactionsService>()(
+  'FilterTransactionsService',
+  {
+    dependencies: [DbService.Default],
+    effect: Effect.gen(function* () {
+      const dbClient = yield* DbService;
+      return Effect.fn(function* (input: {
+        transactions: CommittedTransactionInfo[];
+        stateVersion: number;
+      }) {
         const transactions = transformTransactions(input.transactions);
         const addressTransactionMap = new Map<
           AccountAddress,
@@ -119,6 +112,6 @@ export const FilterTransactionsLive = Layer.effect(
           registeredFeePayers: allRegisteredFeePayers,
         };
       });
-    };
-  }),
-);
+    }),
+  },
+) {}

--- a/packages/api/src/incentives/transaction-stream/transactionStream.ts
+++ b/packages/api/src/incentives/transaction-stream/transactionStream.ts
@@ -1,9 +1,9 @@
-import type { CommittedTransactionInfo } from '@radixdlt/babylon-gateway-api-sdk';
-import { Context, Effect, Layer } from 'effect';
-import type {
+import { Effect } from 'effect';
+import {
   createTransactionStream,
-  TransactionStream,
+  type TransactionStream,
 } from 'radix-transaction-stream';
+import { createRadixNetworkClient } from 'radix-web3.js';
 
 type TransformTransactionResultOutput = ReturnType<
   Awaited<ReturnType<TransactionStream['next']>>['_unsafeUnwrap']
@@ -24,25 +24,10 @@ class UnknownTransactionStreamError {
   constructor(readonly error: unknown) {}
 }
 
-export class TransactionStreamService extends Context.Tag('TransactionStream')<
-  TransactionStreamService,
-  (stateVersion: number) => Effect.Effect<
-    {
-      transactions: CommittedTransactionInfo[];
-      stateVersion: number;
-    },
-    | StateVersionBeyondEndOfKnownLedgerError
-    | RateLimitedError
-    | UnknownTransactionStreamError
-  >
->() {}
-
-export const TransactionStreamLive = (
-  transactionStreamClient: ReturnType<typeof createTransactionStream>,
-) =>
-  Layer.effect(
-    TransactionStreamService,
-    Effect.gen(function* () {
+export class TransactionStreamService extends Effect.Service<TransactionStreamService>()(
+  'TransactionStreamService',
+  {
+    effect: Effect.gen(function* () {
       let backoffMs = 1000;
       const MAX_BACKOFF_MS = 30000;
 
@@ -50,88 +35,101 @@ export const TransactionStreamLive = (
         backoffMs = 1000;
       };
 
-      return (stateVersion: number) =>
-        Effect.gen(function* () {
-          const exponentialBackoff = () => {
-            console.log(`sleeping for ${backoffMs}ms`);
-            return Effect.sleep(backoffMs).pipe(
-              Effect.tap(() => {
-                console.log('waking up');
-                backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
-              }),
+      const transactionStreamClient = createTransactionStream({
+        gatewayApi: createRadixNetworkClient({
+          networkId: 1,
+        }),
+        optIns: {
+          detailed_events: true,
+          balance_changes: true,
+          manifest_instructions: true,
+        },
+        startStateVersion: 1,
+      });
 
-              Effect.map(() => ({
-                transactions: [],
-                stateVersion,
-              })),
-            );
-          };
-
-          transactionStreamClient.setStateVersion(stateVersion);
-
-          const result = yield* Effect.tryPromise({
-            try: () => transactionStreamClient.next(),
-            catch: (e) => new UnknownTransactionStreamError(e),
-          }).pipe(
-            Effect.flatMap(
-              (
-                result,
-              ): Effect.Effect<
-                TransformTransactionResultOutput,
-                | StateVersionBeyondEndOfKnownLedgerError
-                | RateLimitedError
-                | UnknownTransactionStreamError
-              > => {
-                if (result.isOk()) return Effect.succeed(result.value);
-
-                const error = result.error;
-
-                const isStateVersionBeyondEndOfKnownLedgerError =
-                  typeof error === 'object' &&
-                  error !== null &&
-                  'parsedError' in error &&
-                  error.parsedError === 'StateVersionBeyondEndOfKnownLedger';
-
-                const isRateLimitedError =
-                  typeof error === 'object' &&
-                  error !== null &&
-                  'status' in error &&
-                  error.status === 429;
-
-                if (isStateVersionBeyondEndOfKnownLedgerError)
-                  return Effect.fail(
-                    new StateVersionBeyondEndOfKnownLedgerError(error),
-                  );
-
-                if (isRateLimitedError)
-                  return Effect.fail(new RateLimitedError(error));
-
-                return Effect.fail(new UnknownTransactionStreamError(error));
-              },
-            ),
-            Effect.catchTags({
-              RateLimitedError: () => {
-                console.log('Rate limited, waiting...');
-                return exponentialBackoff();
-              },
-              StateVersionBeyondEndOfKnownLedgerError: () => {
-                console.log('Reached the end of the ledger, waiting...');
-                return exponentialBackoff();
-              },
-              UnknownTransactionStreamError: (error) => {
-                console.log('Unknown transaction stream error, waiting...');
-                console.error({ error: error });
-                return exponentialBackoff();
-              },
+      return Effect.fn(function* (stateVersion: number) {
+        // Implementation goes here
+        const exponentialBackoff = () => {
+          console.log(`sleeping for ${backoffMs}ms`);
+          return Effect.sleep(backoffMs).pipe(
+            Effect.tap(() => {
+              console.log('waking up');
+              backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
             }),
+
+            Effect.map(() => ({
+              transactions: [],
+              stateVersion,
+            })),
           );
+        };
 
-          resetBackoff();
+        transactionStreamClient.setStateVersion(stateVersion);
 
-          return {
-            transactions: result.transactions,
-            stateVersion: result.stateVersion,
-          };
-        });
+        const result = yield* Effect.tryPromise({
+          try: () => transactionStreamClient.next(),
+          catch: (e) => new UnknownTransactionStreamError(e),
+        }).pipe(
+          Effect.flatMap(
+            (
+              result,
+            ): Effect.Effect<
+              TransformTransactionResultOutput,
+              | StateVersionBeyondEndOfKnownLedgerError
+              | RateLimitedError
+              | UnknownTransactionStreamError
+            > => {
+              if (result.isOk()) return Effect.succeed(result.value);
+
+              const error = result.error;
+
+              const isStateVersionBeyondEndOfKnownLedgerError =
+                typeof error === 'object' &&
+                error !== null &&
+                'parsedError' in error &&
+                error.parsedError === 'StateVersionBeyondEndOfKnownLedger';
+
+              const isRateLimitedError =
+                typeof error === 'object' &&
+                error !== null &&
+                'status' in error &&
+                error.status === 429;
+
+              if (isStateVersionBeyondEndOfKnownLedgerError)
+                return Effect.fail(
+                  new StateVersionBeyondEndOfKnownLedgerError(error),
+                );
+
+              if (isRateLimitedError)
+                return Effect.fail(new RateLimitedError(error));
+
+              return Effect.fail(new UnknownTransactionStreamError(error));
+            },
+          ),
+          Effect.catchTags({
+            RateLimitedError: () => {
+              console.log('Rate limited, waiting...');
+              return exponentialBackoff();
+            },
+            StateVersionBeyondEndOfKnownLedgerError: () => {
+              console.log('Reached the end of the ledger, waiting...');
+              return exponentialBackoff();
+            },
+            UnknownTransactionStreamError: (error) => {
+              console.log('Unknown transaction stream error, waiting...');
+              console.error({ error: error });
+              return exponentialBackoff();
+            },
+          }),
+        );
+
+        resetBackoff();
+
+        return {
+          transactions: result.transactions,
+          stateVersion: result.stateVersion,
+        };
+      });
     }),
-  );
+  },
+) {}

--- a/packages/api/src/incentives/transaction-stream/transactionStreamLoop.ts
+++ b/packages/api/src/incentives/transaction-stream/transactionStreamLoop.ts
@@ -24,6 +24,16 @@ import {
 export class TransactionStreamLoopService extends Effect.Service<TransactionStreamLoopService>()(
   'TransactionStreamLoopService',
   {
+    dependencies: [
+      TransactionStreamService.Default,
+      ConfigService.Default,
+      FilterTransactionsService.Default,
+      AddEventsToDbService.Default,
+      AddToEventQueueService.Default,
+      AddTransactionFeeService.Default,
+      AddComponentCallsService.Default,
+      ProcessSwapEventTradingVolumeService.Default,
+    ],
     effect: Effect.gen(function* () {
       const transactionStreamService = yield* TransactionStreamService;
       const configService = yield* ConfigService;

--- a/packages/api/src/incentives/transaction-stream/transactionStreamLoopProgram.ts
+++ b/packages/api/src/incentives/transaction-stream/transactionStreamLoopProgram.ts
@@ -1,26 +1,6 @@
-import { db } from 'db/incentives';
 import { Config, Effect, Layer, Schedule } from 'effect';
-import { createTransactionStream } from 'radix-transaction-stream';
-import { createRadixNetworkClient } from 'radix-web3.js';
-import { AddressValidationServiceLive } from '../../common/address-validation/addressValidation';
-import { GatewayApiClientLive } from '../../common/gateway/gatewayApiClient';
 import { GetLedgerStateService } from '../../common/gateway/getLedgerState';
-import { FetchService } from '../../common/helpers/fetch';
-import { AddComponentCallsLive } from '../component/addComponentCalls';
-import { createAppConfigLive, createConfig } from '../config/appConfig';
 import { ConfigService } from '../config/configService';
-import { createDbClientLive } from '../db/dbClient';
-import { AddToEventQueueLive } from '../events/addToEventQueue';
-import { EventQueueClientLive } from '../events/eventQueueClient';
-import { AddEventsToDbLive } from '../events/queries/addEventToDb';
-import { GetUsdValueLive } from '../token-price/getUsdValue';
-import { AddTradingVolumeLive } from '../trading-volume/addTradingVolume';
-import { FilterTradingEventsServiceLive } from '../trading-volume/filterTradingEvents';
-import { ProcessSwapEventTradingVolumeLive } from '../trading-volume/processSwapEventTradingVolume';
-import { AddTransactionFeeLive } from '../transaction-fee/addTransactionFee';
-import { GetUserIdByAccountAddressLive } from '../user/getUserIdByAccountAddress';
-import { FilterTransactionsLive } from './filterTransactions';
-import { TransactionStreamLive } from './transactionStream';
 import { TransactionStreamLoopService } from './transactionStreamLoop';
 import {
   setTransactionStreamState,
@@ -28,121 +8,21 @@ import {
   TransactionStreamLoopState,
 } from './transactionStreamState';
 
-const config = createConfig({
-  networkId: 1,
-  logLevel: 'debug',
-});
+const getLedgerStateLive = GetLedgerStateService.Default;
 
-const configLive = createAppConfigLive(config);
-
-const dbClientLive = createDbClientLive(db);
-
-const apiGatewayClientLive = GatewayApiClientLive.pipe(
-  Layer.provide(configLive),
-);
-
-const getLedgerStateLive = GetLedgerStateService.Default.pipe(
-  Layer.provide(apiGatewayClientLive),
-  Layer.provide(configLive),
-);
-
-const addEventsLive = AddEventsToDbLive.pipe(Layer.provide(dbClientLive));
-
-const getAccountAddressByUserIdLive = GetUserIdByAccountAddressLive.pipe(
-  Layer.provide(dbClientLive),
-);
-
-const addComponentCallsLive = AddComponentCallsLive.pipe(
-  Layer.provide(dbClientLive),
-  Layer.provide(getAccountAddressByUserIdLive),
-);
-
-const transactionStreamClient = createTransactionStream({
-  gatewayApi: createRadixNetworkClient({
-    networkId: config.networkId,
-  }),
-  optIns: {
-    detailed_events: true,
-    balance_changes: true,
-    manifest_instructions: true,
-  },
-  startStateVersion: 1,
-});
-
-const transactionStreamLive = TransactionStreamLive(transactionStreamClient);
-
-const filterTransactionsLive = FilterTransactionsLive.pipe(
-  Layer.provide(dbClientLive),
-);
-
-const eventQueueClientLive = EventQueueClientLive;
-
-const addToEventQueueLive = AddToEventQueueLive.pipe(
-  Layer.provide(eventQueueClientLive),
-);
-
-const addTransactionFeeLive = AddTransactionFeeLive.pipe(
-  Layer.provide(dbClientLive),
-);
-
-const addTradingVolumeLive = AddTradingVolumeLive.pipe(
-  Layer.provide(dbClientLive),
-);
-
-const addressValidationServiceLive = AddressValidationServiceLive;
-
-const getUsdValueLive = GetUsdValueLive.pipe(
-  Layer.provide(addressValidationServiceLive),
-);
-
-const filterTradingEventsLive = FilterTradingEventsServiceLive.pipe(
-  Layer.provide(getUsdValueLive),
-  Layer.provide(addressValidationServiceLive),
-  Layer.provide(dbClientLive),
-);
-
-const processSwapEventTradingVolumeLive =
-  ProcessSwapEventTradingVolumeLive.pipe(
-    Layer.provide(filterTradingEventsLive),
-    Layer.provide(addTradingVolumeLive),
-  );
-
-const configServiceLive = ConfigService.Default.pipe(
-  Layer.provide(dbClientLive),
-  Layer.provide(getLedgerStateLive),
-);
-
-const transactionStreamLoopLive = TransactionStreamLoopService.Default.pipe(
-  Layer.provide(transactionStreamLive),
-  Layer.provide(configServiceLive),
-  Layer.provide(filterTransactionsLive),
-  Layer.provide(addEventsLive),
-  Layer.provide(addToEventQueueLive),
-  Layer.provide(addTransactionFeeLive),
-  Layer.provide(addComponentCallsLive),
-  Layer.provide(processSwapEventTradingVolumeLive),
-  Layer.provide(getLedgerStateLive),
-  Layer.provide(FetchService.Default),
-);
-
-const _RETRY_DELAY = Config.number('TRANSACTION_STREAM_RETRY_DELAY').pipe(
-  Config.withDefault(10),
-);
+const transactionStreamLoopLive = TransactionStreamLoopService.Default;
 
 export const transactionStreamLoopProgram = async () => {
   await Effect.runPromise(
     Effect.gen(function* () {
-      const configService = yield* Effect.provide(
-        ConfigService,
-        configServiceLive,
-      );
+      const configService = yield* ConfigService;
 
       const transactionStreamState =
         yield* configService.getTransactionStreamState();
 
       yield* setTransactionStreamState(transactionStreamState);
     }).pipe(
-      Effect.provide(configServiceLive),
+      Effect.provide(ConfigService.Default),
       Effect.provideService(
         TransactionStreamLoopState,
         sharedTransactionStreamState,
@@ -216,7 +96,7 @@ export const transactionStreamLoopProgram = async () => {
     }),
     Layer.mergeAll(
       transactionStreamLoopLive,
-      configServiceLive,
+      ConfigService.Default,
       getLedgerStateLive,
     ),
   ).pipe(

--- a/packages/api/src/incentives/user/getUserIdByAccountAddress.ts
+++ b/packages/api/src/incentives/user/getUserIdByAccountAddress.ts
@@ -1,45 +1,37 @@
 import { accounts } from 'db/incentives';
 import { inArray } from 'drizzle-orm';
-import { Context, Effect, Layer } from 'effect';
-import { DbClientService, DbError } from '../db/dbClient';
+import { Effect } from 'effect';
+import { DbService } from '../db/dbClient';
 
 type GetAccountsByAddressInput = string[];
 
 type AccountAddress = string;
 type UserId = string;
 
-export class GetUserIdByAccountAddressService extends Context.Tag(
+export class GetUserIdByAccountAddressService extends Effect.Service<GetUserIdByAccountAddressService>()(
   'GetUserIdByAccountAddressService',
-)<
-  GetUserIdByAccountAddressService,
-  (
-    input: GetAccountsByAddressInput,
-  ) => Effect.Effect<Map<AccountAddress, UserId>, DbError>
->() {}
-
-export const GetUserIdByAccountAddressLive = Layer.effect(
-  GetUserIdByAccountAddressService,
-  Effect.gen(function* () {
-    const db = yield* DbClientService;
-
-    return (input) =>
-      Effect.tryPromise({
-        try: () =>
-          db
-            .select({
-              userId: accounts.userId,
-              accountAddress: accounts.address,
-            })
-            .from(accounts)
-            .where(inArray(accounts.address, input)),
-        catch: (error) => new DbError(error),
-      }).pipe(
-        Effect.map((result) =>
-          result.reduce((acc, curr) => {
-            acc.set(curr.accountAddress, curr.userId);
-            return acc;
-          }, new Map<AccountAddress, UserId>()),
-        ),
-      );
-  }),
-);
+  {
+    dependencies: [DbService.Default],
+    effect: Effect.gen(function* () {
+      const db = yield* DbService;
+      return Effect.fn(function* (input: GetAccountsByAddressInput) {
+        // Implementation goes here
+        return yield* db
+          .select({
+            userId: accounts.userId,
+            accountAddress: accounts.address,
+          })
+          .from(accounts)
+          .where(inArray(accounts.address, input))
+          .pipe(
+            Effect.map((result) =>
+              result.reduce((acc, curr) => {
+                acc.set(curr.accountAddress, curr.userId);
+                return acc;
+              }, new Map<AccountAddress, UserId>()),
+            ),
+          );
+      });
+    }),
+  },
+) {}


### PR DESCRIPTION
## Summary
- Refactored API services from Context.Tag + Layer.effect pattern to the modern Effect.Service pattern
- Added explicit dependency declarations for better dependency injection
- Simplified service implementations and removed unnecessary error wrapping

## Changes
- Updated all services to use `Effect.Service()` constructor pattern
- Added explicit `dependencies` declarations for each service
- Simplified service implementation using `Effect.fn` pattern
- Removed unnecessary `DbError` wrapping from database operations
- Consolidated service exports for cleaner API

## Test plan
- [ ] Verify all services compile without errors
- [ ] Run existing tests to ensure no regressions
- [ ] Check that dependency injection works correctly in the applications
- [ ] Verify transaction stream processing still functions as expected

🤖 Generated with [Claude Code](https://claude.ai/code)